### PR TITLE
feat(cli): ship discovery-first auth and incident surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,31 @@ Use grafana-cli to investigate a latency spike in checkout, summarize only key m
 
 - **Compact JSON by default** (`--output json` implied)
 - **Optional readable output**: `--output pretty`
+- **Optional tabular output**: `--output table` for common list and object responses
 - **Structured selection**: `--json`, `--jq`, and `--template` for agent-safe output shaping
 - **Token minimization**: `--fields` remains available as a compatibility alias for `--json`
+- **Schema-driven discovery**: `grafana --help`, `grafana <domain> --help`, and `grafana schema` emit machine-readable command metadata
+- **Agent envelopes**: `--agent` wraps responses in `{status,data,metadata}` for deterministic downstream handling
+- **Read-only guardrail**: `--read-only` blocks mutating commands while keeping investigation workflows available
+- **Explicit destructive confirmations**: `--yes` acknowledges destructive commands such as `auth logout`, `dashboards delete`, and raw API writes
 - **Deterministic command behavior**: stable flags, stable output shapes
 - **Composability**: each command is script/agent safe
+
+## Discovery-First Interface
+
+The CLI now treats discovery as part of the product rather than a side effect of help text.
+
+- `grafana --help` returns a compact root schema for low-token discovery loops.
+- `grafana <domain> --help` returns only the relevant subtree for that domain.
+- `grafana schema` returns the compact contract explicitly.
+- `grafana schema --full [path...]` returns the richer command catalog, workflows, query syntax, and time-format guidance.
+
+This is designed so an agent can answer four questions without opening external docs:
+
+- What commands exist?
+- Which flags are required?
+- What shape will the output have?
+- Which workflows are recommended for investigation?
 
 ## Installation
 
@@ -79,8 +100,11 @@ export PATH="$PATH:$(go env GOPATH)/bin"
 
 ## Current Capabilities
 
+- Discovery + interface contract
+  - `schema [--compact|--full] [path...]`
+  - structured help at root and subtree level
 - Auth/session
-  - `auth login|status|logout`
+  - `auth login|status|doctor|logout`
   - platform-aware token storage: native keyring first, local token file fallback
 - Context and config management
   - `context list|use|view`
@@ -89,12 +113,20 @@ export PATH="$PATH:$(go env GOPATH)/bin"
   - `api <METHOD> <PATH> [--body JSON]`
 - Cloud inventory
   - `cloud stacks list`
+- Investigation context
+  - `query-history list [--search ... --starred --page ... --limit ...]`
+  - `slo list [--query ... --limit ...]`
+  - `irm incidents list [--query ... --limit ...]`
+  - `oncall schedules list [--query ... --limit ...]`
 - Incident + runtime investigation
   - `incident analyze --goal ...`
   - `runtime metrics query --expr ...`
   - `runtime logs query --query ...`
+  - `runtime logs aggregate --query ...`
   - `runtime traces search --query ...`
+  - `runtime traces aggregate --query ...`
   - `aggregate snapshot --metric-expr ... --log-query ... --trace-query ...`
+  - relative or absolute time inputs: `30m`, `now-2h`, `2026-03-06T12:00:00Z`
 - Dashboard and datasource operations
   - `dashboards list --query ... --tag ... --limit ...`
   - `dashboards get --uid ...`
@@ -121,18 +153,19 @@ export PATH="$PATH:$(go env GOPATH)/bin"
 ## Quick Start
 
 ```bash
-grafana -help
-grafana dashboards -help
+grafana --help
+grafana runtime --help
+grafana schema
+grafana schema --full runtime metrics
 
 grafana auth login \
   --token "$GRAFANA_TOKEN" \
-  --base-url "https://your-stack.grafana.net" \
-  --cloud-url "https://grafana.com" \
-  --prom-url "https://prometheus-prod-01-eu-west-0.grafana.net" \
-  --logs-url "https://logs-prod-01-eu-west-0.grafana.net" \
-  --traces-url "https://tempo-prod-01-eu-west-0.grafana.net"
+  --stack "your-stack"
 
 # The token is stored outside config.json using the OS keyring when available.
+
+# Diagnose which capabilities are configured and which endpoints are missing.
+grafana auth doctor
 
 # Create and switch named contexts, like separate stacks or environments.
 grafana auth login --context prod --token "$GRAFANA_TOKEN" --base-url "https://prod.grafana.net"
@@ -144,10 +177,35 @@ grafana config set org-id 12
 # Incident analysis (compact JSON)
 grafana incident analyze --goal "Investigate elevated error rate"
 
+# Pull saved exploration context from recent query history
+grafana query-history list --search checkout --from 24h --limit 20
+
+# Inspect matching SLOs before widening an incident scope
+grafana slo list --query checkout --limit 20
+
+# Inspect recent IRM incidents and OnCall schedules around the same service
+grafana irm incidents list --query checkout --limit 10
+grafana oncall schedules list --query checkout --limit 20
+
 # Return only what the agent needs
 grafana --json summary.metrics_series,summary.log_streams incident analyze --goal "Latency spike"
 grafana --jq '.summary' incident analyze --goal "Latency spike"
 grafana --template '{{.context}} {{.base_url}}' context view
+
+# Use the agent envelope for deterministic downstream parsing
+grafana --agent incident analyze --goal "Latency spike"
+
+# Human-readable inspection for list/object responses
+grafana --output table datasources list
+grafana --output table auth doctor
+
+# Use relative time ranges directly
+grafana runtime logs query --query '{app="checkout"} |= "error"' --start 30m --end now
+grafana runtime logs aggregate --query '{app="checkout"} |= "error"' --start 30m
+grafana runtime traces aggregate --query '{ status = error }' --start 30m
+
+# Prevent accidental writes during investigation
+grafana --read-only dashboards list --query incident
 
 # Talk with Grafana Assistant
 grafana assistant chat --prompt "Investigate elevated error rate in checkout service"
@@ -160,6 +218,9 @@ grafana assistant status --chat-id "chat_123"
 
 # Create a dashboard from JSON template
 grafana dashboards create --template-json '{"title":"Incident Overview","schemaVersion":39,"version":0,"panels":[]}'
+
+# Delete a dashboard explicitly
+grafana --yes dashboards delete --uid "incident-overview"
 
 # Fetch dashboard metadata
 grafana dashboards get --uid "incident-overview"
@@ -174,15 +235,13 @@ Based on current Grafana product/docs research, this CLI targets:
 
 - Grafana core API (dashboards, datasources, folders, alerting, RBAC)
 - Grafana Cloud stacks/control-plane operations
-- Runtime observability data (metrics/logs/traces)
+- Runtime observability data (metrics/logs/traces) plus bounded aggregate summaries
+- Investigation context (query history, SLO definitions, IRM incident previews, and OnCall schedules)
 - Grafana Assistant chat + skills for incident workflows
 - Next planned domains:
-  - IRM/incident response
-  - SLO
   - Synthetic Monitoring
   - k6 performance testing
   - Asserts
-  - OnCall
 
 ## CLI Design Principles
 

--- a/docs/discovery-first-plan.md
+++ b/docs/discovery-first-plan.md
@@ -1,0 +1,380 @@
+# Discovery-First Plan
+
+Date: 2026-03-06
+
+## Goal
+
+Make discovery a first-class interface of `grafana-cli`.
+
+An agent or engineer should be able to answer these questions with one bounded CLI call:
+
+- What can this CLI do?
+- Which command should I run next?
+- Which flags matter?
+- What query syntax is expected?
+- What shape will the output have?
+- How can I stay within a small token budget?
+
+The target is not feature parity with `datadog-pup`.
+The target is a Grafana-native CLI that is easier to discover, cheaper to operate in agent loops, and safer to compose.
+
+## What We Keep
+
+These are already strengths and should remain intact:
+
+- Compact JSON as the default contract.
+- Output shaping with `--json`, `--jq`, and `--template`.
+- Deterministic command behavior.
+- A raw `api` escape hatch for uncovered Grafana surfaces.
+- Context support and token storage outside the config file.
+
+## Product Principles
+
+### 1. Discovery Is Part Of The Product
+
+Every command must be self-describing.
+No new command should ship without:
+
+- a short description
+- flag metadata
+- example invocations
+- expected output shape
+- related commands
+- read/write classification
+- token-cost guidance
+
+### 2. Token Usage Is A Hard Constraint
+
+Discovery must be useful without being verbose.
+The CLI should prefer:
+
+- subtree help over global dumps
+- compact schema over prose
+- summaries over raw payloads
+- bounded list defaults
+- truncation metadata over silent overfetching
+
+### 3. Human And Agent UX Can Differ
+
+Humans need readable help.
+Agents need deterministic schemas.
+The CLI should support both without duplicating command behavior.
+
+### 4. Breadth Follows Clarity
+
+Do not add wide product coverage if discovery, safety, and token discipline are weak.
+Each new domain should first have a clear discovery story.
+
+## Success Criteria
+
+### Discovery
+
+- `grafana --help` returns a compact, structured overview.
+- `grafana <domain> --help` returns only the relevant subtree.
+- `grafana schema --compact` returns a bounded machine-readable contract.
+- Agents can discover query syntax and examples without reading repo docs.
+
+### Token Usage
+
+- Root compact schema should stay within a small single-call budget.
+- Domain schemas should be substantially smaller than root schema.
+- Default list and search commands should include count and truncation metadata when useful.
+- High-frequency workflows should have summary-first commands before raw data commands.
+
+### UX
+
+- A user can authenticate with fewer required inputs.
+- A user can understand missing configuration from CLI output alone.
+- A user can perform a common investigation without falling back to raw API calls.
+
+## Workstreams
+
+### 1. Discovery Surface
+
+### Objective
+
+Give the CLI a first-class discovery contract for both humans and agents.
+
+### Deliverables
+
+- Add a command metadata registry as the single source of truth.
+- Add `grafana schema` with at least:
+  - `--compact`
+  - optional domain/subtree targeting
+- Make `grafana --help` and `grafana <domain> --help` emit structured discovery output.
+- Support human-readable help via `--output pretty` or equivalent rendering.
+
+### Minimum Schema Fields
+
+- `version`
+- `description`
+- `auth`
+- `global_flags`
+- `commands`
+- `query_syntax`
+- `time_formats`
+- `workflows`
+- `best_practices`
+- `anti_patterns`
+
+### Per-Command Metadata
+
+- `name`
+- `full_path`
+- `description`
+- `flags`
+- `read_only`
+- `examples`
+- `output_shape`
+- `related_commands`
+- `token_cost`
+
+### Notes
+
+- Root help should stay compact by default.
+- Domain help should include only domain-relevant query syntax and workflows.
+- The schema must be generated from code metadata, not maintained by hand in multiple places.
+
+### 2. Token-Efficient Discovery Contract
+
+### Objective
+
+Make discovery cheap enough for repeated use in agent loops.
+
+### Deliverables
+
+- Define compact and expanded schema modes.
+- Introduce subtree-targeted help everywhere.
+- Add output metadata for list/search responses:
+  - `count`
+  - `truncated`
+  - `next_action`
+- Add token-cost labels to commands and workflows.
+
+### Token Budget Rules
+
+- Compact schema is the default machine-readable help.
+- Expanded discovery must be opt-in.
+- Large domains should expose focused subtree help instead of one large blob.
+- Help text should favor examples and field names over long explanation paragraphs.
+- Default responses should omit raw nested payloads unless explicitly requested.
+- Summary commands should be preferred for first-pass investigation.
+
+### Example Contract Direction
+
+- `grafana --help` -> compact root schema
+- `grafana runtime --help` -> runtime-only schema
+- `grafana schema --compact` -> explicit compact contract
+- `grafana schema --full runtime` -> richer domain contract when needed
+
+### 3. Authentication And Setup Simplification
+
+### Objective
+
+Reduce setup friction so discovery remains useful after the first command.
+
+### Current Problem
+
+`grafana auth login` can require a token plus multiple URLs for base, cloud, metrics, logs, and traces.
+That is too much surface area up front.
+
+### Deliverables
+
+- Allow login from a single stack identifier when possible.
+- Resolve Prometheus, Loki, and Tempo endpoints automatically from stack metadata.
+- Add an auth diagnostics surface, for example:
+  - `grafana auth doctor`
+  - richer `grafana auth status`
+- Report which capabilities are unavailable because of missing URLs or scopes.
+
+### Output Requirements
+
+- Auth status should show resolved endpoints.
+- Missing configuration should be explicit and actionable.
+- Output should stay compact and omit null-heavy payloads.
+
+### 4. Runtime Investigation Ergonomics
+
+### Objective
+
+Move from thin API wrappers to a better investigation interface.
+
+### Current Problem
+
+The runtime surface is narrow:
+
+- `runtime metrics query`
+- `runtime logs query`
+- `runtime traces search`
+- `aggregate snapshot`
+
+This is usable, but it is not yet optimized for progressive investigation.
+
+### Deliverables
+
+- Add relative time parsing such as `5m`, `1h`, `24h`, `7d`.
+- Add clearer runtime verbs such as search, list, and aggregate where the backend supports them.
+- Add domain-specific query syntax examples to runtime help.
+- Add bounded defaults and truncation metadata.
+- Add service-oriented entry points where Grafana data can support them.
+
+### Preferred Investigation Pattern
+
+1. Aggregate to find the hotspot.
+2. Narrow by service, route, or label.
+3. Fetch a small set of examples.
+4. Escalate to raw payloads only when needed.
+
+### Initial Candidate Additions
+
+- `runtime logs aggregate`
+- `runtime traces aggregate`
+- query examples for PromQL, LogQL, and TraceQL
+- relative time support across runtime commands
+
+### 5. Incident Envelope Coverage
+
+### Objective
+
+Prioritize the product areas that make investigation complete, not just possible.
+
+### First Domains To Add
+
+- SLO
+- IRM / incidents
+- OnCall
+- Synthetic Monitoring
+- Query history
+
+### Second Wave
+
+- Profiles / continuous profiling
+- Application Observability
+- Frontend Observability
+- Knowledge Graph
+- richer cloud administration
+
+### Rule
+
+Do not add a new domain unless it ships with:
+
+- structured help
+- query or filter examples
+- bounded default outputs
+- read/write classification
+
+### 6. Safety And Output Modes
+
+### Objective
+
+Make command execution safer and easier to interpret in both human and agent contexts.
+
+### Deliverables
+
+- Add a global `--read-only` mode.
+- Add a human-oriented table renderer for common list commands.
+- Consider YAML output only if it adds real value beyond JSON and pretty output.
+- Introduce a standard agent envelope for selected commands:
+  - `status`
+  - `data`
+  - `metadata`
+
+### Metadata Fields
+
+- `count`
+- `truncated`
+- `command`
+- `next_action`
+- optional warnings
+
+### Guardrails
+
+- Destructive commands should require explicit confirmation or `--yes`.
+- Agent mode should avoid interactive hangs.
+- Response envelopes should not bloat single-object results unnecessarily.
+
+### 7. Preserve Grafana-Specific Advantages
+
+### Objective
+
+Improve discovery without turning the CLI into a clone of another product.
+
+### Rules
+
+- Keep `api` as the escape hatch.
+- Keep `--json`, `--jq`, and `--template` as first-class features.
+- Prefer narrow Grafana-native commands over a huge number of thin wrappers.
+- Use discovery metadata to guide users toward the narrow command before they fall back to `api`.
+
+## Proposed Phasing
+
+### Phase 1: Discovery Foundation
+
+- Build command metadata registry.
+- Implement `grafana schema --compact`.
+- Make root and subtree help schema-driven.
+- Add discovery tests for stability and coverage.
+
+Exit criteria:
+
+- Root and subtree help are generated from one source of truth.
+- Compact schema is usable by agents without external docs.
+
+### Phase 2: Token And Output Contract
+
+- Add compact vs expanded schema modes.
+- Add response metadata for list/search style commands.
+- Define token-cost guidance and response-size defaults.
+- Preserve current projection tools.
+
+Exit criteria:
+
+- Agents can discover and operate the CLI without large help payloads.
+- Common list/search results signal truncation and next steps.
+
+### Phase 3: Auth Simplification
+
+- Add endpoint inference from a smaller login surface.
+- Improve auth status and diagnostics.
+- Document missing-capability reporting.
+
+Exit criteria:
+
+- Login no longer requires manual product endpoint entry in the common case.
+- Status output explains what is configured and what is not.
+
+### Phase 4: Runtime UX Upgrade
+
+- Add relative time parsing.
+- Add runtime aggregate patterns and better help.
+- Introduce progressive investigation examples.
+
+Exit criteria:
+
+- Runtime commands support a clear summary-first investigation loop.
+
+### Phase 5: Incident Envelope
+
+- Add SLO, IRM, OnCall, Synthetic Monitoring, and query history.
+- Keep discovery metadata mandatory for every new domain.
+
+Exit criteria:
+
+- An incident workflow can stay inside `grafana-cli` for the common case.
+
+## Metrics To Track
+
+- Median token size of root help.
+- Median token size of domain help.
+- Median token size of first-pass investigation workflows.
+- Percentage of commands with complete metadata coverage.
+- Percentage of new domains shipped with query syntax and examples.
+- Percentage of user workflows that avoid raw `api`.
+
+## Immediate Next Steps
+
+1. Define the command metadata model in code.
+2. Implement `grafana schema --compact` using current commands only.
+3. Convert root help and one subtree help path to the new model.
+4. Add response metadata to one runtime command and one list command.
+5. Prototype auth endpoint inference before broadening product coverage.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -8,8 +8,10 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"text/template"
@@ -55,6 +57,9 @@ type globalOptions struct {
 	Fields   []string
 	JQ       string
 	Template string
+	Agent    bool
+	ReadOnly bool
+	Yes      bool
 }
 
 // App coordinates command parsing and execution.
@@ -91,16 +96,32 @@ func (a *App) Run(ctx context.Context, args []string) int {
 	}
 
 	if len(rest) == 0 || isHelpArg(rest[0]) {
-		_ = a.emit(opts, map[string]any{
-			"commands": []string{"auth", "context", "config", "api", "cloud", "dashboards", "datasources", "folders", "annotations", "alerting", "assistant", "runtime", "aggregate", "incident", "agent"},
-		})
+		_ = a.emitHelp(opts, nil, true)
 		return 0
+	}
+	if helpPath, ok := requestedHelpPath(rest); ok {
+		_ = a.emitHelp(opts, helpPath, true)
+		return 0
+	}
+	if !opts.Yes {
+		if err := enforceConfirmation(rest); err != nil {
+			a.printErr(err)
+			return 1
+		}
+	}
+	if opts.ReadOnly {
+		if err := enforceReadOnly(rest); err != nil {
+			a.printErr(err)
+			return 1
+		}
 	}
 
 	var runErr error
 	switch rest[0] {
+	case "schema":
+		runErr = a.runSchema(opts, rest[1:])
 	case "auth":
-		runErr = a.runAuth(opts, rest[1:])
+		runErr = a.runAuth(ctx, opts, rest[1:])
 	case "context":
 		runErr = a.runContext(opts, rest[1:])
 	case "config":
@@ -119,6 +140,10 @@ func (a *App) Run(ctx context.Context, args []string) int {
 		runErr = a.runAnnotations(ctx, opts, rest[1:])
 	case "alerting":
 		runErr = a.runAlerting(ctx, opts, rest[1:])
+	case "query-history":
+		runErr = a.runQueryHistory(ctx, opts, rest[1:])
+	case "slo":
+		runErr = a.runSLO(ctx, opts, rest[1:])
 	case "assistant":
 		runErr = a.runAssistant(ctx, opts, rest[1:])
 	case "runtime":
@@ -127,6 +152,10 @@ func (a *App) Run(ctx context.Context, args []string) int {
 		runErr = a.runAggregate(ctx, opts, rest[1:])
 	case "incident":
 		runErr = a.runIncident(ctx, opts, rest[1:])
+	case "irm":
+		runErr = a.runIRM(ctx, opts, rest[1:])
+	case "oncall":
+		runErr = a.runOnCall(ctx, opts, rest[1:])
 	case "agent":
 		runErr = a.runAgent(ctx, opts, rest[1:])
 	default:
@@ -140,34 +169,26 @@ func (a *App) Run(ctx context.Context, args []string) int {
 	return 0
 }
 
-func (a *App) runAuth(opts globalOptions, args []string) error {
+func (a *App) runAuth(ctx context.Context, opts globalOptions, args []string) error {
 	if len(args) == 0 || isHelpArg(args[0]) {
-		return a.emit(opts, map[string]any{"commands": []string{"login", "status", "logout"}})
+		return a.emitHelp(opts, []string{"auth"}, true)
 	}
 
 	switch args[0] {
 	case "login":
-		return a.runAuthLogin(opts, args[1:])
+		return a.runAuthLogin(ctx, opts, args[1:])
 	case "status":
 		cfg, err := a.Store.Load()
 		if err != nil {
 			return err
 		}
-		status := "unauthenticated"
-		if cfg.IsAuthenticated() {
-			status = "authenticated"
+		return a.emit(opts, authStatusPayload(selectedContextName(a.Contexts, ""), cfg))
+	case "doctor":
+		cfg, err := a.Store.Load()
+		if err != nil {
+			return err
 		}
-		return a.emit(opts, map[string]any{
-			"context":        selectedContextName(a.Contexts, ""),
-			"status":         status,
-			"base_url":       cfg.BaseURL,
-			"cloud_url":      cfg.CloudURL,
-			"prometheus_url": cfg.PrometheusURL,
-			"logs_url":       cfg.LogsURL,
-			"traces_url":     cfg.TracesURL,
-			"token_backend":  cfg.TokenBackend,
-			"org_id":         cfg.OrgID,
-		})
+		return a.emit(opts, authDoctorPayload(selectedContextName(a.Contexts, ""), cfg))
 	case "logout":
 		if err := a.Store.Clear(); err != nil {
 			return err
@@ -178,17 +199,20 @@ func (a *App) runAuth(opts globalOptions, args []string) error {
 	}
 }
 
-func (a *App) runAuthLogin(opts globalOptions, args []string) error {
+func (a *App) runAuthLogin(ctx context.Context, opts globalOptions, args []string) error {
 	fs := flag.NewFlagSet("auth login", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 
 	token := fs.String("token", "", "Grafana token")
 	contextName := fs.String("context", "", "context name")
+	stack := fs.String("stack", "", "Grafana Cloud stack slug or https://<stack>.grafana.net URL")
+	cloudToken := fs.String("cloud-token", "", "Grafana Cloud API token used only for endpoint discovery")
 	baseURL := fs.String("base-url", "", "Grafana base URL")
 	cloudURL := fs.String("cloud-url", "", "Grafana cloud API URL")
 	promURL := fs.String("prom-url", "", "Prometheus query URL")
 	logsURL := fs.String("logs-url", "", "Loki query URL")
 	tracesURL := fs.String("traces-url", "", "Tempo query URL")
+	oncallURL := fs.String("oncall-url", "", "Grafana OnCall API URL")
 	orgID := fs.Int64("org-id", 0, "Grafana org ID")
 
 	if err := fs.Parse(args); err != nil {
@@ -204,20 +228,18 @@ func (a *App) runAuthLogin(opts globalOptions, args []string) error {
 	}
 
 	cfg.Token = strings.TrimSpace(*token)
-	if strings.TrimSpace(*baseURL) != "" {
-		cfg.BaseURL = strings.TrimSpace(*baseURL)
-	}
-	if strings.TrimSpace(*cloudURL) != "" {
-		cfg.CloudURL = strings.TrimSpace(*cloudURL)
-	}
-	if strings.TrimSpace(*promURL) != "" {
-		cfg.PrometheusURL = strings.TrimSpace(*promURL)
-	}
-	if strings.TrimSpace(*logsURL) != "" {
-		cfg.LogsURL = strings.TrimSpace(*logsURL)
-	}
-	if strings.TrimSpace(*tracesURL) != "" {
-		cfg.TracesURL = strings.TrimSpace(*tracesURL)
+	warnings, err := a.resolveAuthEndpoints(ctx, &cfg, authLoginRequest{
+		Stack:      strings.TrimSpace(*stack),
+		CloudToken: strings.TrimSpace(*cloudToken),
+		BaseURL:    strings.TrimSpace(*baseURL),
+		CloudURL:   strings.TrimSpace(*cloudURL),
+		PromURL:    strings.TrimSpace(*promURL),
+		LogsURL:    strings.TrimSpace(*logsURL),
+		TracesURL:  strings.TrimSpace(*tracesURL),
+		OnCallURL:  strings.TrimSpace(*oncallURL),
+	})
+	if err != nil {
+		return err
 	}
 	if *orgID > 0 {
 		cfg.OrgID = *orgID
@@ -234,16 +256,11 @@ func (a *App) runAuthLogin(opts globalOptions, args []string) error {
 		return err
 	}
 
-	return a.emit(opts, map[string]any{
-		"context":        selectedContextName(a.Contexts, *contextName),
-		"status":         "authenticated",
-		"base_url":       cfg.BaseURL,
-		"cloud_url":      cfg.CloudURL,
-		"prometheus_url": cfg.PrometheusURL,
-		"logs_url":       cfg.LogsURL,
-		"traces_url":     cfg.TracesURL,
-		"org_id":         cfg.OrgID,
-	})
+	status := authStatusPayload(selectedContextName(a.Contexts, *contextName), cfg)
+	if len(warnings) > 0 {
+		status["warnings"] = warnings
+	}
+	return a.emit(opts, status)
 }
 
 func (a *App) runContext(opts globalOptions, args []string) error {
@@ -251,7 +268,7 @@ func (a *App) runContext(opts globalOptions, args []string) error {
 		return errors.New("context support is unavailable")
 	}
 	if len(args) == 0 || isHelpArg(args[0]) {
-		return a.emit(opts, map[string]any{"commands": []string{"list", "use", "view"}})
+		return a.emitHelp(opts, []string{"context"}, true)
 	}
 
 	switch args[0] {
@@ -302,7 +319,7 @@ func (a *App) runContext(opts globalOptions, args []string) error {
 
 func (a *App) runConfig(opts globalOptions, args []string) error {
 	if len(args) == 0 || isHelpArg(args[0]) {
-		return a.emit(opts, map[string]any{"commands": []string{"list", "get", "set"}})
+		return a.emitHelp(opts, []string{"config"}, true)
 	}
 
 	switch args[0] {
@@ -369,6 +386,9 @@ func (a *App) runConfig(opts globalOptions, args []string) error {
 }
 
 func (a *App) runAPI(ctx context.Context, opts globalOptions, args []string) error {
+	if len(args) == 0 || isHelpArg(args[0]) {
+		return a.emitHelp(opts, []string{"api"}, true)
+	}
 	if len(args) < 2 {
 		return errors.New("usage: api <METHOD> <PATH> [--body JSON]")
 	}
@@ -405,11 +425,8 @@ func (a *App) runAPI(ctx context.Context, opts globalOptions, args []string) err
 }
 
 func (a *App) runCloud(ctx context.Context, opts globalOptions, args []string) error {
-	if len(args) == 0 {
-		return errors.New("usage: cloud stacks list")
-	}
-	if isHelpArg(args[0]) {
-		return a.emit(opts, map[string]any{"commands": []string{"stacks list"}})
+	if len(args) == 0 || isHelpArg(args[0]) {
+		return a.emitHelp(opts, []string{"cloud"}, true)
 	}
 	if args[0] != "stacks" {
 		return fmt.Errorf("unknown cloud command: %s", args[0])
@@ -425,15 +442,12 @@ func (a *App) runCloud(ctx context.Context, opts globalOptions, args []string) e
 	if err != nil {
 		return err
 	}
-	return a.emit(opts, result)
+	return a.emitWithMetadata(opts, result, collectionMetadata("cloud stacks list", result, 0, ""))
 }
 
 func (a *App) runDashboards(ctx context.Context, opts globalOptions, args []string) error {
-	if len(args) == 0 {
-		return errors.New("usage: dashboards <list|get|create|delete|versions|render>")
-	}
-	if isHelpArg(args[0]) {
-		return a.emit(opts, map[string]any{"commands": []string{"list", "get", "create", "delete", "versions", "render"}})
+	if len(args) == 0 || isHelpArg(args[0]) {
+		return a.emitHelp(opts, []string{"dashboards"}, true)
 	}
 
 	cfg, err := a.requireAuthConfig()
@@ -456,7 +470,7 @@ func (a *App) runDashboards(ctx context.Context, opts globalOptions, args []stri
 		if err != nil {
 			return err
 		}
-		return a.emit(opts, result)
+		return a.emitWithMetadata(opts, result, collectionMetadata("dashboards list", result, *limit, "Narrow --query or --tag, or raise --limit if you need more dashboards"))
 	case "get":
 		fs := flag.NewFlagSet("dashboards get", flag.ContinueOnError)
 		fs.SetOutput(io.Discard)
@@ -599,8 +613,8 @@ func (a *App) runDashboards(ctx context.Context, opts globalOptions, args []stri
 }
 
 func (a *App) runDatasources(ctx context.Context, opts globalOptions, args []string) error {
-	if len(args) > 0 && isHelpArg(args[0]) {
-		return a.emit(opts, map[string]any{"commands": []string{"list"}})
+	if len(args) == 0 || isHelpArg(args[0]) {
+		return a.emitHelp(opts, []string{"datasources"}, true)
 	}
 	if len(args) == 0 || args[0] != "list" {
 		return errors.New("usage: datasources list [--type TYPE] [--name NAME]")
@@ -623,15 +637,12 @@ func (a *App) runDatasources(ctx context.Context, opts globalOptions, args []str
 		return err
 	}
 	result = filterDatasources(result, *typeFilter, *nameFilter)
-	return a.emit(opts, result)
+	return a.emitWithMetadata(opts, result, collectionMetadata("datasources list", result, 0, ""))
 }
 
 func (a *App) runFolders(ctx context.Context, opts globalOptions, args []string) error {
-	if len(args) == 0 {
-		return errors.New("usage: folders <list|get>")
-	}
-	if isHelpArg(args[0]) {
-		return a.emit(opts, map[string]any{"commands": []string{"list", "get"}})
+	if len(args) == 0 || isHelpArg(args[0]) {
+		return a.emitHelp(opts, []string{"folders"}, true)
 	}
 
 	cfg, err := a.requireAuthConfig()
@@ -649,7 +660,7 @@ func (a *App) runFolders(ctx context.Context, opts globalOptions, args []string)
 		if err != nil {
 			return err
 		}
-		return a.emit(opts, result)
+		return a.emitWithMetadata(opts, result, collectionMetadata("folders list", result, 0, ""))
 	case "get":
 		fs := flag.NewFlagSet("folders get", flag.ContinueOnError)
 		fs.SetOutput(io.Discard)
@@ -671,8 +682,8 @@ func (a *App) runFolders(ctx context.Context, opts globalOptions, args []string)
 }
 
 func (a *App) runAnnotations(ctx context.Context, opts globalOptions, args []string) error {
-	if len(args) > 0 && isHelpArg(args[0]) {
-		return a.emit(opts, map[string]any{"commands": []string{"list"}})
+	if len(args) == 0 || isHelpArg(args[0]) {
+		return a.emitHelp(opts, []string{"annotations"}, true)
 	}
 	if len(args) == 0 || args[0] != "list" {
 		return errors.New("usage: annotations list [--dashboard-uid UID] [--panel-id ID] [--limit 100] [--from VALUE] [--to VALUE] [--tags a,b] [--type annotation]")
@@ -707,12 +718,12 @@ func (a *App) runAnnotations(ctx context.Context, opts globalOptions, args []str
 	if err != nil {
 		return err
 	}
-	return a.emit(opts, result)
+	return a.emitWithMetadata(opts, result, collectionMetadata("annotations list", result, *limit, "Add --dashboard-uid, --panel-id, or --tags to narrow the annotation set"))
 }
 
 func (a *App) runAlerting(ctx context.Context, opts globalOptions, args []string) error {
-	if len(args) > 0 && isHelpArg(args[0]) {
-		return a.emit(opts, map[string]any{"commands": []string{"rules list", "contact-points list", "policies get"}})
+	if len(args) == 0 || isHelpArg(args[0]) {
+		return a.emitHelp(opts, []string{"alerting"}, true)
 	}
 	if len(args) < 2 {
 		return errors.New("usage: alerting <rules|contact-points|policies> <list|get>")
@@ -733,7 +744,7 @@ func (a *App) runAlerting(ctx context.Context, opts globalOptions, args []string
 		if err != nil {
 			return err
 		}
-		return a.emit(opts, result)
+		return a.emitWithMetadata(opts, result, collectionMetadata("alerting rules list", result, 0, ""))
 	case "contact-points":
 		if args[1] != "list" || len(args) != 2 {
 			return errors.New("usage: alerting contact-points list")
@@ -742,7 +753,7 @@ func (a *App) runAlerting(ctx context.Context, opts globalOptions, args []string
 		if err != nil {
 			return err
 		}
-		return a.emit(opts, result)
+		return a.emitWithMetadata(opts, result, collectionMetadata("alerting contact-points list", result, 0, ""))
 	case "policies":
 		if args[1] != "get" || len(args) != 2 {
 			return errors.New("usage: alerting policies get")
@@ -757,12 +768,108 @@ func (a *App) runAlerting(ctx context.Context, opts globalOptions, args []string
 	}
 }
 
-func (a *App) runAssistant(ctx context.Context, opts globalOptions, args []string) error {
-	if len(args) == 0 {
-		return errors.New("usage: assistant <chat|status|skills>")
+func (a *App) runQueryHistory(ctx context.Context, opts globalOptions, args []string) error {
+	if len(args) == 0 || isHelpArg(args[0]) {
+		return a.emitHelp(opts, []string{"query-history"}, true)
 	}
-	if isHelpArg(args[0]) {
-		return a.emit(opts, map[string]any{"commands": []string{"chat", "status", "skills"}})
+	if args[0] != "list" {
+		return errors.New("usage: query-history list [--datasource-uid UID[,UID...]] [--search TEXT] [--starred] [--sort time-desc|time-asc] [--page 1] [--limit 100] [--from 24h] [--to now]")
+	}
+
+	fs := flag.NewFlagSet("query-history list", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	datasourceUID := fs.String("datasource-uid", "", "comma-separated datasource UIDs")
+	search := fs.String("search", "", "search string")
+	starred := fs.Bool("starred", false, "only starred queries")
+	sortOrder := fs.String("sort", "time-desc", "time-desc or time-asc")
+	page := fs.Int("page", 1, "page number")
+	limit := fs.Int("limit", 100, "page size")
+	from := fs.String("from", "", "time range start")
+	to := fs.String("to", "", "time range end")
+	if err := fs.Parse(args[1:]); err != nil {
+		return err
+	}
+	if *page < 1 {
+		return errors.New("--page must be at least 1")
+	}
+	if *limit < 1 {
+		return errors.New("--limit must be at least 1")
+	}
+	if *sortOrder != "time-desc" && *sortOrder != "time-asc" {
+		return errors.New("--sort must be time-desc or time-asc")
+	}
+
+	cfg, err := a.requireAuthConfig()
+	if err != nil {
+		return err
+	}
+	query := url.Values{}
+	for _, uid := range splitCSV(*datasourceUID) {
+		query.Add("datasourceUid", uid)
+	}
+	if strings.TrimSpace(*search) != "" {
+		query.Set("searchString", strings.TrimSpace(*search))
+	}
+	if *starred {
+		query.Set("onlyStarred", "true")
+	}
+	query.Set("sort", *sortOrder)
+	query.Set("page", strconv.Itoa(*page))
+	query.Set("limit", strconv.Itoa(*limit))
+	if fromValue := normalizeQueryHistoryBound(a.Now(), *from); fromValue != "" {
+		query.Set("from", fromValue)
+	}
+	if toValue := normalizeQueryHistoryBound(a.Now(), *to); toValue != "" {
+		query.Set("to", toValue)
+	}
+
+	result, err := a.NewClient(cfg).Raw(ctx, "GET", appendQuery("/api/query-history", query), nil)
+	if err != nil {
+		return err
+	}
+	return a.emitWithMetadata(opts, result, queryHistoryMetadata(result, *limit))
+}
+
+func (a *App) runSLO(ctx context.Context, opts globalOptions, args []string) error {
+	if len(args) == 0 || isHelpArg(args[0]) {
+		return a.emitHelp(opts, []string{"slo"}, true)
+	}
+	if args[0] != "list" {
+		return errors.New("usage: slo list [--query TEXT] [--limit 100]")
+	}
+
+	fs := flag.NewFlagSet("slo list", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	query := fs.String("query", "", "name or description filter")
+	limit := fs.Int("limit", 100, "maximum SLOs to return")
+	if err := fs.Parse(args[1:]); err != nil {
+		return err
+	}
+	if *limit < 1 {
+		return errors.New("--limit must be at least 1")
+	}
+
+	cfg, err := a.requireAuthConfig()
+	if err != nil {
+		return err
+	}
+	result, err := a.NewClient(cfg).Raw(ctx, "GET", "/api/plugins/grafana-slo-app/resources/v1/slo", nil)
+	if err != nil {
+		return err
+	}
+	filtered, count, truncated := filterNamedPayload(result, strings.TrimSpace(*query), *limit, "name", "description", "uid", "id")
+	meta := &responseMetadata{Command: "slo list"}
+	meta.Count = &count
+	if truncated {
+		meta.Truncated = true
+		meta.NextAction = "Narrow --query or raise --limit to inspect more SLO definitions"
+	}
+	return a.emitWithMetadata(opts, filtered, meta)
+}
+
+func (a *App) runAssistant(ctx context.Context, opts globalOptions, args []string) error {
+	if len(args) == 0 || isHelpArg(args[0]) {
+		return a.emitHelp(opts, []string{"assistant"}, true)
 	}
 
 	cfg, err := a.requireAuthConfig()
@@ -811,18 +918,18 @@ func (a *App) runAssistant(ctx context.Context, opts globalOptions, args []strin
 		if err != nil {
 			return err
 		}
-		return a.emit(opts, result)
+		return a.emitWithMetadata(opts, result, collectionMetadata("assistant skills", result, 0, ""))
 	default:
 		return fmt.Errorf("unknown assistant command: %s", args[0])
 	}
 }
 
 func (a *App) runRuntime(ctx context.Context, opts globalOptions, args []string) error {
-	if len(args) > 0 && isHelpArg(args[0]) {
-		return a.emit(opts, map[string]any{"commands": []string{"metrics query", "logs query", "traces search"}})
+	if len(args) == 0 || isHelpArg(args[0]) {
+		return a.emitHelp(opts, []string{"runtime"}, true)
 	}
 	if len(args) < 2 {
-		return errors.New("usage: runtime <metrics|logs|traces> <query|search> [flags]")
+		return errors.New("usage: runtime <metrics|logs|traces> <query|search|aggregate> [flags]")
 	}
 
 	cfg, err := a.requireAuthConfig()
@@ -848,16 +955,17 @@ func (a *App) runRuntime(ctx context.Context, opts globalOptions, args []string)
 		if strings.TrimSpace(*expr) == "" {
 			return errors.New("--expr is required")
 		}
-		result, err := client.MetricsRange(ctx, *expr, *start, *end, *step)
+		startValue, endValue := normalizeTimeRange(a.Now(), *start, *end, time.Hour)
+		result, err := client.MetricsRange(ctx, *expr, startValue, endValue, *step)
 		if err != nil {
 			return err
 		}
-		return a.emit(opts, result)
+		return a.emitWithMetadata(opts, result, withCommandMetadata(collectionMetadata("runtime metrics query", result, 0, ""), "runtime metrics query"))
 	case "logs":
-		if args[1] != "query" {
-			return errors.New("usage: runtime logs query --query QUERY [--start RFC3339] [--end RFC3339] [--limit 200]")
+		if args[1] != "query" && args[1] != "aggregate" {
+			return errors.New("usage: runtime logs <query|aggregate> --query QUERY [--start RFC3339] [--end RFC3339] [--limit 200]")
 		}
-		fs := flag.NewFlagSet("runtime logs query", flag.ContinueOnError)
+		fs := flag.NewFlagSet("runtime logs "+args[1], flag.ContinueOnError)
 		fs.SetOutput(io.Discard)
 		query := fs.String("query", "", "LogQL query")
 		start := fs.String("start", "", "RFC3339 start")
@@ -869,16 +977,21 @@ func (a *App) runRuntime(ctx context.Context, opts globalOptions, args []string)
 		if strings.TrimSpace(*query) == "" {
 			return errors.New("--query is required")
 		}
-		result, err := client.LogsRange(ctx, *query, *start, *end, *limit)
+		startValue, endValue := normalizeTimeRange(a.Now(), *start, *end, time.Hour)
+		result, err := client.LogsRange(ctx, *query, startValue, endValue, *limit)
 		if err != nil {
 			return err
 		}
-		return a.emit(opts, result)
-	case "traces":
-		if args[1] != "search" {
-			return errors.New("usage: runtime traces search --query QUERY [--start RFC3339] [--end RFC3339] [--limit 200]")
+		if args[1] == "aggregate" {
+			summary := summarizeLogsResult(result)
+			return a.emitWithMetadata(opts, summary, runtimeAggregateMetadata("runtime logs aggregate", summary["streams"]))
 		}
-		fs := flag.NewFlagSet("runtime traces search", flag.ContinueOnError)
+		return a.emitWithMetadata(opts, result, collectionMetadata("runtime logs query", result, *limit, "Narrow the LogQL query or reduce the time window if you only need representative log streams"))
+	case "traces":
+		if args[1] != "search" && args[1] != "aggregate" {
+			return errors.New("usage: runtime traces <search|aggregate> --query QUERY [--start RFC3339] [--end RFC3339] [--limit 200]")
+		}
+		fs := flag.NewFlagSet("runtime traces "+args[1], flag.ContinueOnError)
 		fs.SetOutput(io.Discard)
 		query := fs.String("query", "", "TraceQL query")
 		start := fs.String("start", "", "RFC3339 start")
@@ -890,19 +1003,24 @@ func (a *App) runRuntime(ctx context.Context, opts globalOptions, args []string)
 		if strings.TrimSpace(*query) == "" {
 			return errors.New("--query is required")
 		}
-		result, err := client.TracesSearch(ctx, *query, *start, *end, *limit)
+		startValue, endValue := normalizeTimeRange(a.Now(), *start, *end, time.Hour)
+		result, err := client.TracesSearch(ctx, *query, startValue, endValue, *limit)
 		if err != nil {
 			return err
 		}
-		return a.emit(opts, result)
+		if args[1] == "aggregate" {
+			summary := summarizeTracesResult(result)
+			return a.emitWithMetadata(opts, summary, runtimeAggregateMetadata("runtime traces aggregate", summary["trace_matches"]))
+		}
+		return a.emitWithMetadata(opts, result, collectionMetadata("runtime traces search", result, *limit, "Narrow the TraceQL expression or shrink the time range for a smaller result set"))
 	default:
 		return fmt.Errorf("unknown runtime command: %s", args[0])
 	}
 }
 
 func (a *App) runAggregate(ctx context.Context, opts globalOptions, args []string) error {
-	if len(args) > 0 && isHelpArg(args[0]) {
-		return a.emit(opts, map[string]any{"commands": []string{"snapshot"}})
+	if len(args) == 0 || isHelpArg(args[0]) {
+		return a.emitHelp(opts, []string{"aggregate"}, true)
 	}
 	if len(args) == 0 || args[0] != "snapshot" {
 		return errors.New("usage: aggregate snapshot --metric-expr EXPR --log-query QUERY --trace-query QUERY [--start RFC3339] [--end RFC3339] [--step 30s] [--limit 200]")
@@ -924,6 +1042,7 @@ func (a *App) runAggregate(ctx context.Context, opts globalOptions, args []strin
 	if strings.TrimSpace(*metricExpr) == "" || strings.TrimSpace(*logQuery) == "" || strings.TrimSpace(*traceQuery) == "" {
 		return errors.New("--metric-expr, --log-query, and --trace-query are required")
 	}
+	startValue, endValue := normalizeTimeRange(a.Now(), *start, *end, time.Hour)
 
 	cfg, err := a.requireAuthConfig()
 	if err != nil {
@@ -933,8 +1052,8 @@ func (a *App) runAggregate(ctx context.Context, opts globalOptions, args []strin
 		MetricExpr: *metricExpr,
 		LogQuery:   *logQuery,
 		TraceQuery: *traceQuery,
-		Start:      *start,
-		End:        *end,
+		Start:      startValue,
+		End:        endValue,
 		Step:       *step,
 		Limit:      *limit,
 	})
@@ -945,8 +1064,8 @@ func (a *App) runAggregate(ctx context.Context, opts globalOptions, args []strin
 }
 
 func (a *App) runIncident(ctx context.Context, opts globalOptions, args []string) error {
-	if len(args) > 0 && isHelpArg(args[0]) {
-		return a.emit(opts, map[string]any{"commands": []string{"analyze"}})
+	if len(args) == 0 || isHelpArg(args[0]) {
+		return a.emitHelp(opts, []string{"incident"}, true)
 	}
 	if len(args) == 0 || args[0] != "analyze" {
 		return errors.New("usage: incident analyze --goal GOAL [--start RFC3339] [--end RFC3339] [--step 30s] [--limit 200] [--include-raw]")
@@ -999,6 +1118,7 @@ func (a *App) runIncident(ctx context.Context, opts globalOptions, args []string
 	if *limit > 0 {
 		req.Limit = *limit
 	}
+	req.Start, req.End = normalizeTimeRange(a.Now(), req.Start, req.End, time.Hour)
 
 	snapshot, err := client.AggregateSnapshot(ctx, req)
 	if err != nil {
@@ -1019,12 +1139,93 @@ func (a *App) runIncident(ctx context.Context, opts globalOptions, args []string
 	return a.emit(opts, result)
 }
 
-func (a *App) runAgent(ctx context.Context, opts globalOptions, args []string) error {
-	if len(args) == 0 {
-		return errors.New("usage: agent <plan|run> --goal GOAL")
+func (a *App) runIRM(ctx context.Context, opts globalOptions, args []string) error {
+	if len(args) == 0 || isHelpArg(args[0]) {
+		return a.emitHelp(opts, []string{"irm"}, true)
 	}
-	if isHelpArg(args[0]) {
-		return a.emit(opts, map[string]any{"commands": []string{"plan", "run"}})
+	if len(args) < 2 || args[0] != "incidents" || args[1] != "list" {
+		return errors.New("usage: irm incidents list [--query TEXT] [--limit 20] [--order-field createdAt] [--order-direction desc]")
+	}
+
+	fs := flag.NewFlagSet("irm incidents list", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	query := fs.String("query", "", "incident search text")
+	limit := fs.Int("limit", 20, "maximum incidents")
+	orderField := fs.String("order-field", "createdAt", "incident sort field")
+	orderDirection := fs.String("order-direction", "desc", "asc or desc")
+	if err := fs.Parse(args[2:]); err != nil {
+		return err
+	}
+	if *limit < 1 {
+		return errors.New("--limit must be at least 1")
+	}
+	if *orderDirection != "asc" && *orderDirection != "desc" {
+		return errors.New("--order-direction must be asc or desc")
+	}
+
+	cfg, err := a.requireAuthConfig()
+	if err != nil {
+		return err
+	}
+	body := map[string]any{
+		"query": map[string]any{
+			"limit":       *limit,
+			"queryString": strings.TrimSpace(*query),
+			"orderBy": map[string]any{
+				"field":     strings.TrimSpace(*orderField),
+				"direction": *orderDirection,
+			},
+		},
+	}
+	result, err := a.NewClient(cfg).Raw(ctx, "POST", "/api/plugins/grafana-irm-app/resources/api/v1/IncidentsService.QueryIncidentPreviews", body)
+	if err != nil {
+		return err
+	}
+	return a.emitWithMetadata(opts, result, collectionMetadata("irm incidents list", result, *limit, "Refine --query or lower --limit to inspect a tighter incident slice"))
+}
+
+func (a *App) runOnCall(ctx context.Context, opts globalOptions, args []string) error {
+	if len(args) == 0 || isHelpArg(args[0]) {
+		return a.emitHelp(opts, []string{"oncall"}, true)
+	}
+	if len(args) < 2 || args[0] != "schedules" || args[1] != "list" {
+		return errors.New("usage: oncall schedules list [--query TEXT] [--limit 50]")
+	}
+
+	fs := flag.NewFlagSet("oncall schedules list", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	query := fs.String("query", "", "schedule name or team filter")
+	limit := fs.Int("limit", 50, "maximum schedules")
+	if err := fs.Parse(args[2:]); err != nil {
+		return err
+	}
+	if *limit < 1 {
+		return errors.New("--limit must be at least 1")
+	}
+
+	cfg, err := a.requireOnCallConfig()
+	if err != nil {
+		return err
+	}
+	onCallCfg := cfg
+	onCallCfg.BaseURL = cfg.OnCallURL
+	result, err := a.NewClient(onCallCfg).Raw(ctx, "GET", "/api/v1/schedules/", nil)
+	if err != nil {
+		return err
+	}
+	filtered, count, truncated := filterNamedPayload(result, strings.TrimSpace(*query), *limit, "name", "team.name", "team.slug", "type")
+	meta := &responseMetadata{Command: "oncall schedules list"}
+	meta.Count = &count
+	if truncated || payloadHasNextPage(result) {
+		meta.Truncated = true
+		meta.NextAction = "Refine --query or lower --limit to inspect specific OnCall schedules"
+	}
+	return a.emitWithMetadata(opts, filtered, meta)
+}
+
+func (a *App) runAgent(ctx context.Context, opts globalOptions, args []string) error {
+	if len(args) == 0 || isHelpArg(args[0]) {
+		return a.emitHelp(opts, []string{"agent"}, true)
 	}
 
 	fs := flag.NewFlagSet("agent", flag.ContinueOnError)
@@ -1075,6 +1276,403 @@ func (a *App) runAgent(ctx context.Context, opts globalOptions, args []string) e
 	}
 }
 
+func (a *App) runSchema(opts globalOptions, args []string) error {
+	fs := flag.NewFlagSet("schema", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	compact := fs.Bool("compact", false, "return a smaller schema")
+	full := fs.Bool("full", false, "return the expanded schema")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *compact && *full {
+		return errors.New("--compact and --full cannot be used together")
+	}
+	return a.emitHelp(opts, fs.Args(), !*full)
+}
+
+type authLoginRequest struct {
+	Stack      string
+	CloudToken string
+	BaseURL    string
+	CloudURL   string
+	PromURL    string
+	LogsURL    string
+	TracesURL  string
+	OnCallURL  string
+}
+
+type inferredStackEndpoints struct {
+	PrometheusURL string
+	LogsURL       string
+	TracesURL     string
+	OnCallURL     string
+}
+
+func authStatusPayload(contextName string, cfg config.Config) map[string]any {
+	capabilities, missing := authCapabilities(cfg)
+	status := "unauthenticated"
+	if cfg.IsAuthenticated() {
+		status = "authenticated"
+	}
+	return map[string]any{
+		"context":        contextName,
+		"status":         status,
+		"authenticated":  cfg.IsAuthenticated(),
+		"base_url":       cfg.BaseURL,
+		"cloud_url":      cfg.CloudURL,
+		"prometheus_url": cfg.PrometheusURL,
+		"logs_url":       cfg.LogsURL,
+		"traces_url":     cfg.TracesURL,
+		"oncall_url":     cfg.OnCallURL,
+		"token_backend":  cfg.TokenBackend,
+		"org_id":         cfg.OrgID,
+		"missing":        missing,
+		"capabilities":   capabilities,
+	}
+}
+
+func authCapabilities(cfg config.Config) ([]map[string]any, []string) {
+	capabilities := []map[string]any{
+		{"name": "api", "ok": cfg.IsAuthenticated() && strings.TrimSpace(cfg.BaseURL) != "", "requires": []string{"token", "base_url"}},
+		{"name": "cloud", "ok": cfg.IsAuthenticated() && strings.TrimSpace(cfg.CloudURL) != "", "requires": []string{"token", "cloud_url"}},
+		{"name": "query_history", "ok": cfg.IsAuthenticated() && strings.TrimSpace(cfg.BaseURL) != "", "requires": []string{"token", "base_url"}},
+		{"name": "slo", "ok": cfg.IsAuthenticated() && strings.TrimSpace(cfg.BaseURL) != "", "requires": []string{"token", "base_url"}},
+		{"name": "irm", "ok": cfg.IsAuthenticated() && strings.TrimSpace(cfg.BaseURL) != "", "requires": []string{"token", "base_url"}},
+		{"name": "oncall", "ok": cfg.IsAuthenticated() && strings.TrimSpace(cfg.OnCallURL) != "", "requires": []string{"token", "oncall_url"}},
+		{"name": "runtime_metrics", "ok": cfg.IsAuthenticated() && strings.TrimSpace(cfg.PrometheusURL) != "", "requires": []string{"token", "prometheus_url"}},
+		{"name": "runtime_logs", "ok": cfg.IsAuthenticated() && strings.TrimSpace(cfg.LogsURL) != "", "requires": []string{"token", "logs_url"}},
+		{"name": "runtime_traces", "ok": cfg.IsAuthenticated() && strings.TrimSpace(cfg.TracesURL) != "", "requires": []string{"token", "traces_url"}},
+	}
+	missing := make([]string, 0, 6)
+	if !cfg.IsAuthenticated() {
+		missing = append(missing, "token")
+	}
+	if strings.TrimSpace(cfg.BaseURL) == "" {
+		missing = append(missing, "base_url")
+	}
+	if strings.TrimSpace(cfg.CloudURL) == "" {
+		missing = append(missing, "cloud_url")
+	}
+	if strings.TrimSpace(cfg.PrometheusURL) == "" {
+		missing = append(missing, "prometheus_url")
+	}
+	if strings.TrimSpace(cfg.LogsURL) == "" {
+		missing = append(missing, "logs_url")
+	}
+	if strings.TrimSpace(cfg.TracesURL) == "" {
+		missing = append(missing, "traces_url")
+	}
+	if strings.TrimSpace(cfg.OnCallURL) == "" {
+		missing = append(missing, "oncall_url")
+	}
+	return capabilities, missing
+}
+
+func authDoctorPayload(contextName string, cfg config.Config) map[string]any {
+	payload := authStatusPayload(contextName, cfg)
+	missing, _ := payload["missing"].([]string)
+	suggestions := make([]string, 0, 2)
+	if !cfg.IsAuthenticated() {
+		suggestions = append(suggestions, `Run grafana auth login --token "$GRAFANA_TOKEN" --stack "<stack-slug>"`)
+	}
+	if len(missing) > 0 {
+		suggestions = append(suggestions, "Resolve missing endpoints with grafana auth login --stack <stack-slug> or set them manually with grafana config set")
+	}
+	payload["suggestions"] = suggestions
+	return payload
+}
+
+func (a *App) resolveAuthEndpoints(ctx context.Context, cfg *config.Config, req authLoginRequest) ([]string, error) {
+	req.BaseURL = strings.TrimSpace(req.BaseURL)
+	req.CloudURL = strings.TrimSpace(req.CloudURL)
+	req.PromURL = strings.TrimSpace(req.PromURL)
+	req.LogsURL = strings.TrimSpace(req.LogsURL)
+	req.TracesURL = strings.TrimSpace(req.TracesURL)
+	req.OnCallURL = strings.TrimSpace(req.OnCallURL)
+	req.Stack = strings.TrimSpace(req.Stack)
+	req.CloudToken = strings.TrimSpace(req.CloudToken)
+
+	warnings := make([]string, 0, 2)
+	if req.Stack != "" {
+		stackSlug, inferredBaseURL, err := normalizeStackIdentifier(req.Stack)
+		if err != nil {
+			return nil, err
+		}
+		if req.BaseURL == "" {
+			cfg.BaseURL = inferredBaseURL
+		}
+		if req.CloudURL == "" && strings.TrimSpace(cfg.CloudURL) == "" {
+			defaults := config.Config{}
+			defaults.ApplyDefaults()
+			cfg.CloudURL = defaults.CloudURL
+		}
+		if req.PromURL == "" {
+			cfg.PrometheusURL = ""
+		}
+		if req.LogsURL == "" {
+			cfg.LogsURL = ""
+		}
+		if req.TracesURL == "" {
+			cfg.TracesURL = ""
+		}
+		if req.OnCallURL == "" {
+			cfg.OnCallURL = ""
+		}
+		discoveryWarnings := a.applyInferredStackEndpoints(ctx, cfg, stackSlug, req.CloudToken)
+		warnings = append(warnings, discoveryWarnings...)
+	}
+	if req.BaseURL != "" {
+		cfg.BaseURL = req.BaseURL
+	}
+	if req.CloudURL != "" {
+		cfg.CloudURL = req.CloudURL
+	}
+	if req.PromURL != "" {
+		cfg.PrometheusURL = req.PromURL
+	}
+	if req.LogsURL != "" {
+		cfg.LogsURL = req.LogsURL
+	}
+	if req.TracesURL != "" {
+		cfg.TracesURL = req.TracesURL
+	}
+	if req.OnCallURL != "" {
+		cfg.OnCallURL = req.OnCallURL
+	}
+	return warnings, nil
+}
+
+func (a *App) applyInferredStackEndpoints(ctx context.Context, cfg *config.Config, stackSlug, cloudToken string) []string {
+	token := strings.TrimSpace(cloudToken)
+	if token == "" {
+		token = cfg.Token
+	}
+	cloudClient := a.NewClient(config.Config{
+		BaseURL:  cfg.CloudURL,
+		CloudURL: cfg.CloudURL,
+		Token:    token,
+	})
+	warnings := make([]string, 0, 2)
+
+	datasources, err := cloudClient.Raw(ctx, "GET", "/api/instances/"+url.PathEscape(stackSlug)+"/datasources", nil)
+	if err != nil {
+		warnings = append(warnings, fmt.Sprintf("stack datasource discovery failed: %v", err))
+	} else {
+		endpoints := inferDatasourceEndpoints(datasources)
+		if endpoints.PrometheusURL != "" {
+			cfg.PrometheusURL = endpoints.PrometheusURL
+		}
+		if endpoints.LogsURL != "" {
+			cfg.LogsURL = endpoints.LogsURL
+		}
+		if endpoints.TracesURL != "" {
+			cfg.TracesURL = endpoints.TracesURL
+		}
+	}
+
+	connections, err := cloudClient.Raw(ctx, "GET", "/api/instances/"+url.PathEscape(stackSlug)+"/connections", nil)
+	if err != nil {
+		warnings = append(warnings, fmt.Sprintf("stack connection discovery failed: %v", err))
+	} else if onCallURL := inferOnCallURL(connections); onCallURL != "" {
+		cfg.OnCallURL = onCallURL
+	}
+	return warnings
+}
+
+func normalizeStackIdentifier(value string) (string, string, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "", "", errors.New("stack identifier is required")
+	}
+	if strings.Contains(trimmed, "://") {
+		parsed, err := url.Parse(trimmed)
+		if err != nil {
+			return "", "", fmt.Errorf("invalid --stack value: %w", err)
+		}
+		host := strings.ToLower(strings.TrimSpace(parsed.Hostname()))
+		if !strings.HasSuffix(host, ".grafana.net") {
+			return "", "", errors.New("--stack URL must target a *.grafana.net host")
+		}
+		slug := strings.TrimSuffix(host, ".grafana.net")
+		return slug, parsed.Scheme + "://" + parsed.Host, nil
+	}
+	host := strings.ToLower(trimmed)
+	if strings.Contains(host, ".") {
+		if !strings.HasSuffix(host, ".grafana.net") {
+			return "", "", errors.New("--stack must be a Grafana Cloud slug or *.grafana.net host")
+		}
+		slug := strings.TrimSuffix(host, ".grafana.net")
+		return slug, "https://" + host, nil
+	}
+	return host, "https://" + host + ".grafana.net", nil
+}
+
+func inferDatasourceEndpoints(payload any) inferredStackEndpoints {
+	items, _, ok := collectionPayload(payload)
+	if !ok {
+		return inferredStackEndpoints{}
+	}
+	out := inferredStackEndpoints{}
+	for _, item := range items {
+		record, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		dataType := strings.ToLower(firstNonEmptyString(record, "type", "slug", "name"))
+		endpoint := firstNonEmptyString(record, "url", "endpoint", "proxyUrl", "proxy_url")
+		switch {
+		case endpoint == "":
+			continue
+		case out.PrometheusURL == "" && containsAny(dataType, "prometheus", "mimir"):
+			out.PrometheusURL = endpoint
+		case out.LogsURL == "" && containsAny(dataType, "loki", "logs"):
+			out.LogsURL = endpoint
+		case out.TracesURL == "" && containsAny(dataType, "tempo", "traces"):
+			out.TracesURL = endpoint
+		}
+	}
+	return out
+}
+
+func inferOnCallURL(payload any) string {
+	if root, ok := payload.(map[string]any); ok {
+		if urlValue := firstNonEmptyString(root, "oncallApiUrl"); urlValue != "" {
+			return urlValue
+		}
+	}
+	items, _, ok := collectionPayload(payload)
+	if !ok {
+		if nested := collectionAtPath(payload, "connections"); len(nested) > 0 {
+			items = nested
+			ok = true
+		}
+	}
+	if !ok {
+		return ""
+	}
+	for _, item := range items {
+		record, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		hint := strings.ToLower(firstNonEmptyString(record, "type", "name", "kind"))
+		if !containsAny(hint, "oncall") {
+			continue
+		}
+		if urlValue := recursiveStringValue(record, "oncallApiUrl"); urlValue != "" {
+			return urlValue
+		}
+		if urlValue := firstNonEmptyString(record, "url", "apiUrl", "api_url"); urlValue != "" {
+			return urlValue
+		}
+	}
+	return ""
+}
+
+func recursiveStringValue(payload any, key string) string {
+	switch typed := payload.(type) {
+	case map[string]any:
+		if value := firstNonEmptyString(typed, key); value != "" {
+			return value
+		}
+		for _, child := range typed {
+			if value := recursiveStringValue(child, key); value != "" {
+				return value
+			}
+		}
+	case []any:
+		for _, child := range typed {
+			if value := recursiveStringValue(child, key); value != "" {
+				return value
+			}
+		}
+	}
+	return ""
+}
+
+func containsAny(value string, parts ...string) bool {
+	for _, part := range parts {
+		if strings.Contains(value, part) {
+			return true
+		}
+	}
+	return false
+}
+
+func payloadHasNextPage(payload any) bool {
+	root, ok := payload.(map[string]any)
+	if !ok {
+		return false
+	}
+	return strings.TrimSpace(firstNonEmptyString(root, "next", "nextPage")) != ""
+}
+
+func enforceConfirmation(args []string) error {
+	for _, arg := range args {
+		if isHelpArg(arg) {
+			return nil
+		}
+	}
+	if len(args) == 0 {
+		return nil
+	}
+	if args[0] == "api" {
+		if len(args) < 2 {
+			return nil
+		}
+		method := strings.ToUpper(args[1])
+		switch method {
+		case "GET", "HEAD", "OPTIONS":
+			return nil
+		default:
+			path := ""
+			if len(args) > 2 {
+				path = " " + args[2]
+			}
+			return fmt.Errorf("requires --yes: api %s%s mutates remote state", method, path)
+		}
+	}
+	switch strings.Join(discoveryPathFromArgs(args), " ") {
+	case "auth logout":
+		return errors.New("requires --yes: auth logout clears stored credentials")
+	case "dashboards delete":
+		return errors.New("requires --yes: dashboards delete removes a dashboard")
+	default:
+		return nil
+	}
+}
+
+func enforceReadOnly(args []string) error {
+	for _, arg := range args {
+		if isHelpArg(arg) {
+			return nil
+		}
+	}
+	if len(args) == 0 {
+		return nil
+	}
+	if args[0] == "api" {
+		if len(args) < 2 {
+			return nil
+		}
+		switch strings.ToUpper(args[1]) {
+		case "GET", "HEAD", "OPTIONS":
+			return nil
+		default:
+			return errors.New("blocked by --read-only: api write methods are disabled")
+		}
+	}
+	path := discoveryPathFromArgs(args)
+	if len(path) == 0 {
+		return nil
+	}
+	command, ok := findDiscoveryCommand(discoveryCatalog(), path)
+	if ok && !command.ReadOnly {
+		return fmt.Errorf("blocked by --read-only: %s mutates state", strings.Join(path, " "))
+	}
+	return nil
+}
+
 func (a *App) requireAuthConfig() (config.Config, error) {
 	cfg, err := a.Store.Load()
 	if err != nil {
@@ -1086,8 +1684,19 @@ func (a *App) requireAuthConfig() (config.Config, error) {
 	return cfg, nil
 }
 
+func (a *App) requireOnCallConfig() (config.Config, error) {
+	cfg, err := a.requireAuthConfig()
+	if err != nil {
+		return config.Config{}, err
+	}
+	if strings.TrimSpace(cfg.OnCallURL) == "" {
+		return config.Config{}, errors.New("oncall URL is not configured: run `grafana auth login --stack ...` or `grafana config set oncall-url ...`")
+	}
+	return cfg, nil
+}
+
 func parseGlobalOptions(args []string) (globalOptions, []string, error) {
-	opts := globalOptions{Output: "json"}
+	opts := globalOptions{Output: "json", Agent: isTruthyEnv("FORCE_AGENT_MODE") || isTruthyEnv("GRAFANA_CLI_AGENT_MODE")}
 	rest := make([]string, 0, len(args))
 
 	for i := 0; i < len(args); i++ {
@@ -1135,12 +1744,18 @@ func parseGlobalOptions(args []string) (globalOptions, []string, error) {
 			i++
 		case strings.HasPrefix(arg, "--template="):
 			opts.Template = strings.TrimPrefix(arg, "--template=")
+		case arg == "--agent":
+			opts.Agent = true
+		case arg == "--read-only":
+			opts.ReadOnly = true
+		case arg == "--yes":
+			opts.Yes = true
 		default:
 			rest = append(rest, arg)
 		}
 	}
 
-	if opts.Output != "json" && opts.Output != "pretty" {
+	if opts.Output != "json" && opts.Output != "pretty" && opts.Output != "table" {
 		return globalOptions{}, nil, fmt.Errorf("invalid --output value: %s", opts.Output)
 	}
 	if opts.JQ != "" && opts.Template != "" {
@@ -1150,6 +1765,10 @@ func parseGlobalOptions(args []string) (globalOptions, []string, error) {
 }
 
 func (a *App) emit(opts globalOptions, payload any) error {
+	return a.emitWithMetadata(opts, payload, nil)
+}
+
+func (a *App) emitWithMetadata(opts globalOptions, payload any, meta *responseMetadata) error {
 	payload = projectFields(payload, opts.Fields)
 	if opts.JQ != "" {
 		value, err := applyJQ(payload, opts.JQ)
@@ -1161,15 +1780,42 @@ func (a *App) emit(opts globalOptions, payload any) error {
 	if opts.Template != "" {
 		return renderTemplate(a.Out, payload, opts.Template)
 	}
+	if opts.Agent {
+		if meta == nil {
+			meta = collectionMetadata("", payload, 0, "")
+		} else if meta.Count == nil {
+			if count, ok := inferMetadataCount(payload); ok {
+				meta.Count = &count
+			}
+		}
+		enc := json.NewEncoder(a.Out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(responseEnvelope{
+			Status:   "success",
+			Data:     payload,
+			Metadata: meta,
+		})
+	}
 	if isScalar(payload) {
 		_, err := fmt.Fprintln(a.Out, scalarString(payload))
 		return err
+	}
+	if opts.Output == "table" {
+		return renderTable(a.Out, payload)
 	}
 	enc := json.NewEncoder(a.Out)
 	if opts.Output == "pretty" {
 		enc.SetIndent("", "  ")
 	}
 	return enc.Encode(payload)
+}
+
+func (a *App) emitHelp(opts globalOptions, path []string, compact bool) error {
+	payload, err := buildDiscoveryPayload(path, compact)
+	if err != nil {
+		return err
+	}
+	return a.emit(opts, payload)
 }
 
 func (a *App) printErr(err error) {
@@ -1231,13 +1877,100 @@ func summarizeSnapshot(snapshot grafana.AggregateSnapshot) map[string]any {
 	}
 }
 
+func summarizeLogsResult(payload any) map[string]any {
+	streams := collectionAtPath(payload, "data", "result")
+	labelKeys := map[string]struct{}{}
+	topStreams := make([]any, 0, minInt(len(streams), 5))
+	entryCount := 0
+	validStreams := 0
+	for _, stream := range streams {
+		record, ok := stream.(map[string]any)
+		if !ok {
+			continue
+		}
+		validStreams++
+		labels, _ := record["stream"].(map[string]any)
+		values, _ := record["values"].([]any)
+		entryCount += len(values)
+		for key := range labels {
+			labelKeys[key] = struct{}{}
+		}
+		if len(topStreams) < 5 {
+			topStreams = append(topStreams, map[string]any{
+				"labels":  labels,
+				"entries": len(values),
+			})
+		}
+	}
+	sortedLabels := make([]string, 0, len(labelKeys))
+	for key := range labelKeys {
+		sortedLabels = append(sortedLabels, key)
+	}
+	sort.Strings(sortedLabels)
+	return map[string]any{
+		"streams":     validStreams,
+		"entries":     entryCount,
+		"label_keys":  sortedLabels,
+		"top_streams": topStreams,
+	}
+}
+
+func summarizeTracesResult(payload any) map[string]any {
+	traces := collectionAtPath(payload, "traces")
+	if len(traces) == 0 {
+		traces = collectionAtPath(payload, "data", "traces")
+	}
+	services := map[string]struct{}{}
+	operations := map[string]struct{}{}
+	sampleTraceIDs := make([]string, 0, minInt(len(traces), 5))
+	validTraces := 0
+	for _, trace := range traces {
+		record, ok := trace.(map[string]any)
+		if !ok {
+			continue
+		}
+		validTraces++
+		if service := firstNonEmptyString(record, "rootServiceName", "serviceName", "service"); service != "" {
+			services[service] = struct{}{}
+		}
+		if operation := firstNonEmptyString(record, "rootTraceName", "name", "traceName"); operation != "" {
+			operations[operation] = struct{}{}
+		}
+		if len(sampleTraceIDs) < 5 {
+			if traceID := firstNonEmptyString(record, "traceID", "traceId", "id"); traceID != "" {
+				sampleTraceIDs = append(sampleTraceIDs, traceID)
+			}
+		}
+	}
+	return map[string]any{
+		"trace_matches":    validTraces,
+		"services":         sortedSet(services),
+		"root_operations":  sortedSet(operations),
+		"sample_trace_ids": sampleTraceIDs,
+	}
+}
+
+func runtimeAggregateMetadata(command string, countValue any) *responseMetadata {
+	meta := &responseMetadata{Command: command}
+	if count, ok := intValue(countValue); ok {
+		meta.Count = &count
+	}
+	return meta
+}
+
 func inferCollectionCount(payload any) int {
 	switch v := payload.(type) {
 	case []any:
 		return len(v)
 	case map[string]any:
-		if items, ok := v["items"].([]any); ok {
-			return len(items)
+		for _, key := range collectionKeys {
+			candidate, ok := v[key]
+			if !ok {
+				continue
+			}
+			if count := inferCollectionCount(candidate); count > 0 {
+				return count
+			}
 		}
 	}
 	return 0
@@ -1310,6 +2043,13 @@ func maxInt(a, b int) int {
 	return b
 }
 
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
 func isHelpArg(value string) bool {
 	switch strings.TrimSpace(value) {
 	case "help", "--help", "-h", "-help":
@@ -1365,6 +2105,7 @@ func configPayload(contextName string, cfg config.Config) map[string]any {
 		"prometheus_url": cfg.PrometheusURL,
 		"logs_url":       cfg.LogsURL,
 		"traces_url":     cfg.TracesURL,
+		"oncall_url":     cfg.OnCallURL,
 		"org_id":         cfg.OrgID,
 		"token_backend":  cfg.TokenBackend,
 	}
@@ -1407,6 +2148,8 @@ func configValueForKey(cfg config.Config, key string) (any, error) {
 		return cfg.LogsURL, nil
 	case "traces-url", "traces_url":
 		return cfg.TracesURL, nil
+	case "oncall-url", "oncall_url":
+		return cfg.OnCallURL, nil
 	case "org-id", "org_id":
 		return cfg.OrgID, nil
 	case "token-backend", "token_backend":
@@ -1428,6 +2171,8 @@ func setConfigValue(cfg *config.Config, key, value string) error {
 		cfg.LogsURL = strings.TrimSpace(value)
 	case "traces-url", "traces_url":
 		cfg.TracesURL = strings.TrimSpace(value)
+	case "oncall-url", "oncall_url":
+		cfg.OnCallURL = strings.TrimSpace(value)
 	case "org-id", "org_id":
 		parsed, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
 		if err != nil || parsed < 0 {
@@ -1507,10 +2252,184 @@ func scalarString(value any) string {
 	return fmt.Sprint(value)
 }
 
+func isTruthyEnv(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(name))) {
+	case "1", "true", "yes":
+		return true
+	default:
+		return false
+	}
+}
+
 func parseInt(value string, fallback int) int {
 	parsed, err := strconv.Atoi(value)
 	if err != nil {
 		return fallback
 	}
 	return parsed
+}
+
+func appendQuery(path string, query url.Values) string {
+	encoded := query.Encode()
+	if strings.TrimSpace(encoded) == "" {
+		return path
+	}
+	return path + "?" + encoded
+}
+
+func normalizeQueryHistoryBound(now time.Time, value string) string {
+	normalized := normalizeTimeValue(now, value)
+	if parsed, err := time.Parse(time.RFC3339, normalized); err == nil {
+		return strconv.FormatInt(parsed.UnixMilli(), 10)
+	}
+	return normalized
+}
+
+func queryHistoryMetadata(payload any, limit int) *responseMetadata {
+	meta := &responseMetadata{Command: "query-history list"}
+	if count := countPath(payload, "result", "queryHistory"); count > 0 {
+		meta.Count = &count
+	}
+	if totalCount, ok := intPath(payload, "result", "totalCount"); ok && meta.Count != nil && totalCount > *meta.Count {
+		meta.Truncated = true
+		meta.NextAction = "Use --page or raise --limit to inspect more query-history entries"
+	}
+	if meta.Count == nil && limit > 0 {
+		meta.Warnings = []string{"query-history response did not expose a countable result set"}
+	}
+	return meta
+}
+
+func filterNamedPayload(payload any, query string, limit int, fields ...string) (any, int, bool) {
+	items, wrap, ok := collectionPayload(payload)
+	if !ok {
+		return payload, inferCollectionCount(payload), false
+	}
+	filtered := items
+	if strings.TrimSpace(query) != "" {
+		filtered = make([]any, 0, len(items))
+		for _, item := range items {
+			record, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			if matchesAnyField(record, query, fields...) {
+				filtered = append(filtered, record)
+			}
+		}
+	}
+	count := len(filtered)
+	truncated := false
+	if limit > 0 && len(filtered) > limit {
+		filtered = filtered[:limit]
+		truncated = true
+	}
+	return wrap(filtered), count, truncated
+}
+
+func collectionPayload(payload any) ([]any, func([]any) any, bool) {
+	switch typed := payload.(type) {
+	case []any:
+		return typed, func(items []any) any { return items }, true
+	case map[string]any:
+		for _, key := range []string{"items", "results", "slos"} {
+			items, ok := typed[key].([]any)
+			if !ok {
+				continue
+			}
+			return items, func(filtered []any) any {
+				cloned := map[string]any{}
+				for cloneKey, cloneValue := range typed {
+					cloned[cloneKey] = cloneValue
+				}
+				cloned[key] = filtered
+				return cloned
+			}, true
+		}
+	}
+	return nil, nil, false
+}
+
+func matchesAnyField(record map[string]any, query string, fields ...string) bool {
+	needle := strings.ToLower(strings.TrimSpace(query))
+	if needle == "" {
+		return true
+	}
+	for _, field := range fields {
+		value, ok := lookupPath(record, strings.Split(field, "."))
+		if !ok {
+			continue
+		}
+		if strings.Contains(strings.ToLower(fmt.Sprint(value)), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func collectionAtPath(payload any, path ...string) []any {
+	root, ok := payload.(map[string]any)
+	if !ok {
+		return nil
+	}
+	value, ok := lookupPath(root, path)
+	if !ok {
+		return nil
+	}
+	items, _ := value.([]any)
+	return items
+}
+
+func intPath(payload any, path ...string) (int, bool) {
+	root, ok := payload.(map[string]any)
+	if !ok {
+		return 0, false
+	}
+	value, ok := lookupPath(root, path)
+	if !ok {
+		return 0, false
+	}
+	return intValue(value)
+}
+
+func intValue(value any) (int, bool) {
+	switch typed := value.(type) {
+	case int:
+		return typed, true
+	case int64:
+		return int(typed), true
+	case float64:
+		return int(typed), true
+	case json.Number:
+		n, err := typed.Int64()
+		if err != nil {
+			return 0, false
+		}
+		return int(n), true
+	default:
+		return 0, false
+	}
+}
+
+func firstNonEmptyString(record map[string]any, keys ...string) string {
+	for _, key := range keys {
+		value, ok := record[key]
+		if !ok {
+			continue
+		}
+		trimmed := strings.TrimSpace(fmt.Sprint(value))
+		if trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func sortedSet(values map[string]struct{}) []string {
+	out := make([]string, 0, len(values))
+	for value := range values {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -19,6 +20,19 @@ type fakeStore struct {
 	loadErr  error
 	saveErr  error
 	clearErr error
+}
+
+type failWriter struct {
+	failAfter int
+	writes    int
+}
+
+func (f *failWriter) Write(_ []byte) (int, error) {
+	if f.writes >= f.failAfter {
+		return 0, errors.New("write failure")
+	}
+	f.writes++
+	return 1, nil
 }
 
 func (f *fakeStore) Load() (config.Config, error) {
@@ -175,6 +189,12 @@ func (f *fakeContextStore) SaveContext(name string, cfg config.Config) error {
 type fakeClient struct {
 	rawResult           any
 	rawErr              error
+	rawResponses        map[string]any
+	rawErrors           map[string]error
+	rawMethod           string
+	rawPath             string
+	rawBody             any
+	rawCalls            []string
 	cloudResult         any
 	cloudErr            error
 	searchDashResult    any
@@ -216,10 +236,22 @@ type fakeClient struct {
 	assistantStatusID   string
 	metricsResult       any
 	metricsErr          error
+	metricsExpr         string
+	metricsStart        string
+	metricsEnd          string
+	metricsStep         string
 	logsResult          any
 	logsErr             error
+	logsQuery           string
+	logsStart           string
+	logsEnd             string
+	logsLimit           int
 	tracesResult        any
 	tracesErr           error
+	tracesQuery         string
+	tracesStart         string
+	tracesEnd           string
+	tracesLimit         int
 	aggregateResult     grafana.AggregateSnapshot
 	aggregateErr        error
 	aggregateReq        grafana.AggregateRequest
@@ -228,7 +260,17 @@ type fakeClient struct {
 	createOverwrite     bool
 }
 
-func (f *fakeClient) Raw(_ context.Context, _, _ string, _ any) (any, error) {
+func (f *fakeClient) Raw(_ context.Context, method, path string, body any) (any, error) {
+	f.rawMethod = method
+	f.rawPath = path
+	f.rawBody = body
+	f.rawCalls = append(f.rawCalls, method+" "+path)
+	if err, ok := f.rawErrors[path]; ok {
+		return nil, err
+	}
+	if result, ok := f.rawResponses[path]; ok {
+		return result, nil
+	}
 	return f.rawResult, f.rawErr
 }
 
@@ -308,15 +350,27 @@ func (f *fakeClient) AssistantSkills(_ context.Context) (any, error) {
 	return f.assistantSkillsResp, f.assistantSkillsErr
 }
 
-func (f *fakeClient) MetricsRange(_ context.Context, _, _, _, _ string) (any, error) {
+func (f *fakeClient) MetricsRange(_ context.Context, expr, start, end, step string) (any, error) {
+	f.metricsExpr = expr
+	f.metricsStart = start
+	f.metricsEnd = end
+	f.metricsStep = step
 	return f.metricsResult, f.metricsErr
 }
 
-func (f *fakeClient) LogsRange(_ context.Context, _, _, _ string, _ int) (any, error) {
+func (f *fakeClient) LogsRange(_ context.Context, query, start, end string, limit int) (any, error) {
+	f.logsQuery = query
+	f.logsStart = start
+	f.logsEnd = end
+	f.logsLimit = limit
 	return f.logsResult, f.logsErr
 }
 
-func (f *fakeClient) TracesSearch(_ context.Context, _, _, _ string, _ int) (any, error) {
+func (f *fakeClient) TracesSearch(_ context.Context, query, start, end string, limit int) (any, error) {
+	f.tracesQuery = query
+	f.tracesStart = start
+	f.tracesEnd = end
+	f.tracesLimit = limit
 	return f.tracesResult, f.tracesErr
 }
 
@@ -354,7 +408,25 @@ func decodeJSONArray(t *testing.T, value string) []map[string]any {
 	return out
 }
 
+func findCommandByName(t *testing.T, commands []any, name string) map[string]any {
+	t.Helper()
+	for _, command := range commands {
+		entry, ok := command.(map[string]any)
+		if !ok {
+			continue
+		}
+		if entry["name"] == name {
+			return entry
+		}
+	}
+	t.Fatalf("command %q not found in %#v", name, commands)
+	return nil
+}
+
 func TestParseGlobalOptions(t *testing.T) {
+	t.Setenv("FORCE_AGENT_MODE", "")
+	t.Setenv("GRAFANA_CLI_AGENT_MODE", "")
+
 	opts, rest, err := parseGlobalOptions([]string{"--fields", "a,b", "--output", "pretty", "auth", "status"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -383,14 +455,24 @@ func TestParseGlobalOptions(t *testing.T) {
 	if _, _, err := parseGlobalOptions([]string{"--output", "bad"}); err == nil {
 		t.Fatalf("expected invalid output error")
 	}
+	opts, _, err = parseGlobalOptions([]string{"--output", "table", "--agent", "--read-only", "--yes", "auth", "status"})
+	if err != nil {
+		t.Fatalf("unexpected error for table/agent/read-only/yes: %v", err)
+	}
+	if opts.Output != "table" || !opts.Agent || !opts.ReadOnly || !opts.Yes {
+		t.Fatalf("unexpected opts for table/agent/read-only/yes: %+v", opts)
+	}
 }
 
 func TestParseGlobalOptionsExtended(t *testing.T) {
+	t.Setenv("FORCE_AGENT_MODE", "1")
+	t.Setenv("GRAFANA_CLI_AGENT_MODE", "")
+
 	opts, rest, err := parseGlobalOptions([]string{"--json", "a,b", "--jq", ".x", "context", "view"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if opts.Output != "json" || opts.JQ != ".x" || len(opts.Fields) != 2 {
+	if opts.Output != "json" || opts.JQ != ".x" || len(opts.Fields) != 2 || !opts.Agent {
 		t.Fatalf("unexpected opts: %+v", opts)
 	}
 	if len(rest) != 2 || rest[0] != "context" || rest[1] != "view" {
@@ -446,22 +528,19 @@ func TestRunHelpAndUnknown(t *testing.T) {
 		t.Fatalf("expected success for help")
 	}
 	resp := decodeJSON(t, out.String())
+	if resp["version"] != cliVersion {
+		t.Fatalf("expected version in discovery help, got %+v", resp)
+	}
 	commands, ok := resp["commands"].([]any)
 	if !ok {
 		t.Fatalf("expected commands output")
 	}
-	foundAssistant := false
-	foundContext := false
-	for _, command := range commands {
-		if value, _ := command.(string); value == "assistant" {
-			foundAssistant = true
-		}
-		if value, _ := command.(string); value == "context" {
-			foundContext = true
-		}
+	assistant := findCommandByName(t, commands, "assistant")
+	if assistant["description"] == "" || assistant["token_cost"] == "" {
+		t.Fatalf("expected assistant command metadata, got %+v", assistant)
 	}
-	if !foundAssistant || !foundContext {
-		t.Fatalf("expected assistant and context commands in help output")
+	if findCommandByName(t, commands, "schema")["description"] == "" {
+		t.Fatalf("expected schema command in root help")
 	}
 
 	out.Reset()
@@ -507,17 +586,43 @@ func TestAuthFlows(t *testing.T) {
 		t.Fatalf("status should succeed")
 	}
 	resp = decodeJSON(t, out.String())
-	if resp["status"] != "authenticated" {
-		t.Fatalf("expected authenticated status")
+	if resp["status"] != "authenticated" || resp["capabilities"] == nil || resp["missing"] == nil {
+		t.Fatalf("expected richer authenticated status, got %+v", resp)
 	}
 
 	out.Reset()
-	if code := app.Run(context.Background(), []string{"auth", "logout"}); code != 0 {
+	if code := app.Run(context.Background(), []string{"auth", "doctor"}); code != 0 {
+		t.Fatalf("doctor should succeed")
+	}
+	doctor := decodeJSON(t, out.String())
+	if doctor["authenticated"] != true || doctor["capabilities"] == nil {
+		t.Fatalf("unexpected doctor response: %+v", doctor)
+	}
+
+	out.Reset()
+	if code := app.Run(context.Background(), []string{"auth", "logout"}); code != 1 {
+		t.Fatalf("logout should require --yes")
+	}
+	if !strings.Contains(errOut.String(), "requires --yes") {
+		t.Fatalf("expected confirmation error, got %s", errOut.String())
+	}
+
+	errOut.Reset()
+	out.Reset()
+	if code := app.Run(context.Background(), []string{"--yes", "auth", "logout"}); code != 0 {
 		t.Fatalf("logout should succeed")
 	}
 	resp = decodeJSON(t, out.String())
 	if resp["status"] != "logged_out" {
 		t.Fatalf("unexpected logout response")
+	}
+
+	out.Reset()
+	if code := app.Run(context.Background(), []string{"auth", "status"}); code != 0 {
+		t.Fatalf("status after logout should succeed")
+	}
+	if decodeJSON(t, out.String())["status"] != "unauthenticated" {
+		t.Fatalf("expected unauthenticated status after logout")
 	}
 
 	if code := app.Run(context.Background(), []string{"auth", "login"}); code != 1 {
@@ -544,6 +649,57 @@ func TestAuthFlows(t *testing.T) {
 	}
 }
 
+func TestAuthLoginStackInference(t *testing.T) {
+	store := &fakeStore{}
+	client := &fakeClient{
+		rawResponses: map[string]any{
+			"/api/instances/prod-observability/datasources": []any{
+				map[string]any{"type": "prometheus", "url": "https://prom.grafana.net"},
+				map[string]any{"type": "loki", "url": "https://logs.grafana.net"},
+				map[string]any{"type": "tempo", "url": "https://traces.grafana.net"},
+			},
+			"/api/instances/prod-observability/connections": []any{
+				map[string]any{"type": "oncall", "oncallApiUrl": "https://oncall.grafana.net"},
+			},
+		},
+	}
+	app, out, errOut := newTestApp(store, client)
+
+	if code := app.Run(context.Background(), []string{"auth", "login", "--token", "abc", "--stack", "https://prod-observability.grafana.net"}); code != 0 {
+		t.Fatalf("stack auth login should succeed: %s", errOut.String())
+	}
+	resp := decodeJSON(t, out.String())
+	if resp["base_url"] != "https://prod-observability.grafana.net" || resp["prometheus_url"] != "https://prom.grafana.net" || resp["oncall_url"] != "https://oncall.grafana.net" {
+		t.Fatalf("expected inferred endpoints in login response, got %+v", resp)
+	}
+	if store.cfg.BaseURL != "https://prod-observability.grafana.net" || store.cfg.PrometheusURL != "https://prom.grafana.net" || store.cfg.OnCallURL != "https://oncall.grafana.net" {
+		t.Fatalf("expected inferred endpoints in stored config, got %+v", store.cfg)
+	}
+	if len(client.rawCalls) != 2 {
+		t.Fatalf("expected two cloud discovery calls, got %+v", client.rawCalls)
+	}
+
+	out.Reset()
+	client = &fakeClient{
+		rawErrors: map[string]error{
+			"/api/instances/prod-observability/datasources": errors.New("discovery failed"),
+		},
+	}
+	app, out, errOut = newTestApp(&fakeStore{}, client)
+	if code := app.Run(context.Background(), []string{"auth", "login", "--token", "abc", "--stack", "prod-observability", "--oncall-url", "https://manual-oncall.grafana.net"}); code != 0 {
+		t.Fatalf("stack auth login with partial discovery should succeed: %s", errOut.String())
+	}
+	resp = decodeJSON(t, out.String())
+	warnings, ok := resp["warnings"].([]any)
+	if !ok || len(warnings) != 1 {
+		t.Fatalf("expected discovery warnings, got %+v", resp)
+	}
+
+	if code := app.Run(context.Background(), []string{"auth", "login", "--token", "abc", "--stack", "https://example.com"}); code != 1 {
+		t.Fatalf("invalid stack host should fail")
+	}
+}
+
 func TestCommandErrorsFromStore(t *testing.T) {
 	store := &fakeStore{loadErr: errors.New("load fail")}
 	client := &fakeClient{}
@@ -554,6 +710,13 @@ func TestCommandErrorsFromStore(t *testing.T) {
 	}
 	if !strings.Contains(errOut.String(), "load fail") {
 		t.Fatalf("expected load fail error")
+	}
+	errOut.Reset()
+	if code := app.Run(context.Background(), []string{"auth", "doctor"}); code != 1 {
+		t.Fatalf("expected doctor failure")
+	}
+	if !strings.Contains(errOut.String(), "load fail") {
+		t.Fatalf("expected doctor load fail error")
 	}
 
 	store = &fakeStore{cfg: config.Config{Token: "x"}, saveErr: errors.New("save fail")}
@@ -567,7 +730,7 @@ func TestCommandErrorsFromStore(t *testing.T) {
 
 	store = &fakeStore{cfg: config.Config{Token: "x"}, clearErr: errors.New("clear fail")}
 	app, _, errOut = newTestApp(store, client)
-	if code := app.Run(context.Background(), []string{"auth", "logout"}); code != 1 {
+	if code := app.Run(context.Background(), []string{"--yes", "auth", "logout"}); code != 1 {
 		t.Fatalf("expected clear failure")
 	}
 	if !strings.Contains(errOut.String(), "clear fail") {
@@ -623,8 +786,12 @@ func TestAPICloudDashboardDatasourceCommands(t *testing.T) {
 	if decodeJSON(t, out.String())["items"] == nil {
 		t.Fatalf("unexpected cloud output")
 	}
-	if code := app.Run(context.Background(), []string{"cloud"}); code != 1 {
-		t.Fatalf("cloud usage should fail")
+	out.Reset()
+	if code := app.Run(context.Background(), []string{"cloud"}); code != 0 {
+		t.Fatalf("cloud help should succeed")
+	}
+	if _, ok := decodeJSON(t, out.String())["commands"]; !ok {
+		t.Fatalf("expected cloud discovery output")
 	}
 	if code := app.Run(context.Background(), []string{"cloud", "bad"}); code != 1 {
 		t.Fatalf("unknown cloud should fail")
@@ -655,8 +822,12 @@ func TestAPICloudDashboardDatasourceCommands(t *testing.T) {
 	if code := app.Run(context.Background(), []string{"dashboards", "create"}); code != 1 {
 		t.Fatalf("missing dashboard create flags should fail")
 	}
-	if code := app.Run(context.Background(), []string{"dashboards"}); code != 1 {
-		t.Fatalf("missing dashboards subcommand should fail")
+	out.Reset()
+	if code := app.Run(context.Background(), []string{"dashboards"}); code != 0 {
+		t.Fatalf("dashboards help should succeed")
+	}
+	if _, ok := decodeJSON(t, out.String())["commands"]; !ok {
+		t.Fatalf("expected dashboards discovery output")
 	}
 	if code := app.Run(context.Background(), []string{"dashboards", "bad"}); code != 1 {
 		t.Fatalf("unknown dashboard command should fail")
@@ -705,7 +876,7 @@ func TestDashboardFolderAnnotationAndAlertingCommands(t *testing.T) {
 	}
 
 	out.Reset()
-	if code := app.Run(context.Background(), []string{"dashboards", "delete", "--uid", "ops"}); code != 0 {
+	if code := app.Run(context.Background(), []string{"--yes", "dashboards", "delete", "--uid", "ops"}); code != 0 {
 		t.Fatalf("dashboard delete should succeed")
 	}
 	if decodeJSON(t, out.String())["status"] != "deleted" {
@@ -814,7 +985,7 @@ func TestDashboardFolderAnnotationAndAlertingCommands(t *testing.T) {
 	if code := app.Run(context.Background(), []string{"dashboards", "get"}); code != 1 {
 		t.Fatalf("dashboard get missing uid should fail")
 	}
-	if code := app.Run(context.Background(), []string{"dashboards", "delete"}); code != 1 {
+	if code := app.Run(context.Background(), []string{"--yes", "dashboards", "delete"}); code != 1 {
 		t.Fatalf("dashboard delete missing uid should fail")
 	}
 	if code := app.Run(context.Background(), []string{"dashboards", "versions"}); code != 1 {
@@ -829,7 +1000,7 @@ func TestDashboardFolderAnnotationAndAlertingCommands(t *testing.T) {
 	if code := app.Run(context.Background(), []string{"dashboards", "get", "--bad"}); code != 1 {
 		t.Fatalf("dashboard get parse should fail")
 	}
-	if code := app.Run(context.Background(), []string{"dashboards", "delete", "--bad"}); code != 1 {
+	if code := app.Run(context.Background(), []string{"--yes", "dashboards", "delete", "--bad"}); code != 1 {
 		t.Fatalf("dashboard delete parse should fail")
 	}
 	if code := app.Run(context.Background(), []string{"dashboards", "versions", "--bad"}); code != 1 {
@@ -855,8 +1026,12 @@ func TestDashboardFolderAnnotationAndAlertingCommands(t *testing.T) {
 		t.Fatalf("dashboard render directory path should fail")
 	}
 
-	if code := app.Run(context.Background(), []string{"folders"}); code != 1 {
-		t.Fatalf("folders usage should fail")
+	out.Reset()
+	if code := app.Run(context.Background(), []string{"folders"}); code != 0 {
+		t.Fatalf("folders help should succeed")
+	}
+	if _, ok := decodeJSON(t, out.String())["commands"]; !ok {
+		t.Fatalf("expected folders discovery output")
 	}
 	if code := app.Run(context.Background(), []string{"folders", "list", "extra"}); code != 1 {
 		t.Fatalf("folders list usage should fail")
@@ -871,8 +1046,8 @@ func TestDashboardFolderAnnotationAndAlertingCommands(t *testing.T) {
 		t.Fatalf("folders unknown command should fail")
 	}
 
-	if code := app.Run(context.Background(), []string{"annotations"}); code != 1 {
-		t.Fatalf("annotations usage should fail")
+	if code := app.Run(context.Background(), []string{"annotations"}); code != 0 {
+		t.Fatalf("annotations help should succeed")
 	}
 	if code := app.Run(context.Background(), []string{"annotations", "bad"}); code != 1 {
 		t.Fatalf("annotations unknown command should fail")
@@ -881,11 +1056,14 @@ func TestDashboardFolderAnnotationAndAlertingCommands(t *testing.T) {
 		t.Fatalf("annotations parse should fail")
 	}
 
-	if code := app.Run(context.Background(), []string{"alerting"}); code != 1 {
-		t.Fatalf("alerting usage should fail")
+	if code := app.Run(context.Background(), []string{"alerting"}); code != 0 {
+		t.Fatalf("alerting help should succeed")
 	}
 	if code := app.Run(context.Background(), []string{"alerting", "rules", "bad"}); code != 1 {
 		t.Fatalf("alerting rules usage should fail")
+	}
+	if code := app.Run(context.Background(), []string{"alerting", "rules"}); code != 1 {
+		t.Fatalf("alerting rules missing verb should fail")
 	}
 	if code := app.Run(context.Background(), []string{"alerting", "contact-points", "bad"}); code != 1 {
 		t.Fatalf("alerting contact points usage should fail")
@@ -920,6 +1098,8 @@ func TestGroupHelpWithoutAuth(t *testing.T) {
 		{"runtime", "-help"},
 		{"aggregate", "-help"},
 		{"incident", "-help"},
+		{"irm", "-help"},
+		{"oncall", "-help"},
 		{"agent", "-help"},
 	} {
 		out.Reset()
@@ -929,6 +1109,699 @@ func TestGroupHelpWithoutAuth(t *testing.T) {
 		}
 		if _, ok := decodeJSON(t, out.String())["commands"]; !ok {
 			t.Fatalf("expected commands output for %v", args)
+		}
+	}
+}
+
+func TestSchemaCommandAndNestedHelp(t *testing.T) {
+	store := &fakeStore{}
+	client := &fakeClient{}
+	app, out, errOut := newTestApp(store, client)
+
+	if code := app.Run(context.Background(), []string{"schema", "--compact"}); code != 0 {
+		t.Fatalf("schema compact should succeed: %s", errOut.String())
+	}
+	root := decodeJSON(t, out.String())
+	if root["version"] != cliVersion {
+		t.Fatalf("expected schema version, got %+v", root)
+	}
+	if _, ok := root["best_practices"]; ok {
+		t.Fatalf("did not expect expanded docs in compact schema")
+	}
+
+	out.Reset()
+	if code := app.Run(context.Background(), []string{"schema"}); code != 0 {
+		t.Fatalf("schema default should succeed: %s", errOut.String())
+	}
+	if _, ok := decodeJSON(t, out.String())["best_practices"]; ok {
+		t.Fatalf("schema default should stay compact")
+	}
+
+	out.Reset()
+	if code := app.Run(context.Background(), []string{"schema", "--full", "runtime"}); code != 0 {
+		t.Fatalf("schema full runtime should succeed: %s", errOut.String())
+	}
+	runtimeSchema := decodeJSON(t, out.String())
+	if runtimeSchema["scope"] != "runtime" {
+		t.Fatalf("expected runtime scope, got %+v", runtimeSchema)
+	}
+	if _, ok := runtimeSchema["query_syntax"].(map[string]any)["metrics"]; !ok {
+		t.Fatalf("expected runtime query syntax, got %+v", runtimeSchema["query_syntax"])
+	}
+	if _, ok := runtimeSchema["best_practices"].([]any); !ok {
+		t.Fatalf("expected expanded runtime schema docs")
+	}
+
+	out.Reset()
+	if code := app.Run(context.Background(), []string{"runtime", "metrics", "query", "--help"}); code != 0 {
+		t.Fatalf("nested leaf help should succeed: %s", errOut.String())
+	}
+	leaf := decodeJSON(t, out.String())
+	if leaf["scope"] != "runtime metrics query" {
+		t.Fatalf("expected nested help scope, got %+v", leaf)
+	}
+	commands := leaf["commands"].([]any)
+	if len(commands) != 1 {
+		t.Fatalf("expected one leaf command, got %+v", commands)
+	}
+	command := commands[0].(map[string]any)
+	if command["name"] != "query" {
+		t.Fatalf("expected leaf command metadata, got %+v", command)
+	}
+	if _, ok := leaf["query_syntax"].(map[string]any)["metrics"]; !ok {
+		t.Fatalf("expected metrics query syntax in leaf help")
+	}
+
+	if code := app.Run(context.Background(), []string{"schema", "--bad"}); code != 1 {
+		t.Fatalf("schema should fail for unknown flag")
+	}
+	if code := app.Run(context.Background(), []string{"schema", "--compact", "--full"}); code != 1 {
+		t.Fatalf("schema should fail for conflicting compact/full flags")
+	}
+}
+
+func TestDiscoveryHelpers(t *testing.T) {
+	payload, err := buildDiscoveryPayload([]string{"runtime", "logs"}, false)
+	if err != nil {
+		t.Fatalf("unexpected discovery payload error: %v", err)
+	}
+	if payload["scope"] != "runtime logs" {
+		t.Fatalf("expected logs scope, got %+v", payload)
+	}
+	if _, ok := payload["query_syntax"].(map[string]string); !ok {
+		t.Fatalf("expected logs query syntax map, got %#v", payload["query_syntax"])
+	}
+	commands := payload["commands"].([]map[string]any)
+	if commands[0]["output_shape"] == "" {
+		t.Fatalf("expected full discovery payload to include output shape")
+	}
+
+	if _, err := buildDiscoveryPayload([]string{"missing"}, true); err == nil {
+		t.Fatalf("expected unknown schema path error")
+	}
+
+	path, ok := requestedHelpPath([]string{"dashboards", "get", "--help"})
+	if !ok || strings.Join(path, " ") != "dashboards get" {
+		t.Fatalf("unexpected help path: ok=%v path=%v", ok, path)
+	}
+	if path, ok := requestedHelpPath([]string{"dashboards", "get"}); ok || path != nil {
+		t.Fatalf("unexpected help path without help flag: ok=%v path=%v", ok, path)
+	}
+	if strings.Join(discoveryPathFromArgs([]string{"api", "GET", "/api/test"}), " ") != "api" {
+		t.Fatalf("expected api command path")
+	}
+	if workflows := discoveryWorkflows([]string{"dashboards"}); workflows != nil {
+		t.Fatalf("expected no workflows for unrelated discovery scope, got %+v", workflows)
+	}
+}
+
+func TestDiscoveryPayloadBudgets(t *testing.T) {
+	compactRoot, err := buildDiscoveryPayload(nil, true)
+	if err != nil {
+		t.Fatalf("unexpected compact root payload error: %v", err)
+	}
+	fullRoot, err := buildDiscoveryPayload(nil, false)
+	if err != nil {
+		t.Fatalf("unexpected full root payload error: %v", err)
+	}
+	compactBytes, err := json.Marshal(compactRoot)
+	if err != nil {
+		t.Fatalf("unexpected compact root marshal error: %v", err)
+	}
+	fullBytes, err := json.Marshal(fullRoot)
+	if err != nil {
+		t.Fatalf("unexpected full root marshal error: %v", err)
+	}
+	if len(compactBytes) >= len(fullBytes) {
+		t.Fatalf("expected compact discovery payload to be smaller than full: compact=%d full=%d", len(compactBytes), len(fullBytes))
+	}
+	if len(compactBytes) > 20000 {
+		t.Fatalf("compact discovery payload budget exceeded: %d bytes", len(compactBytes))
+	}
+	if _, ok := compactRoot["workflows"]; ok {
+		t.Fatalf("compact discovery payload should omit workflows")
+	}
+	workflows, ok := fullRoot["workflows"].([]discoveryWorkflow)
+	if !ok || len(workflows) == 0 || workflows[0].TokenCost == "" {
+		t.Fatalf("expected full discovery workflows with token cost, got %+v", fullRoot["workflows"])
+	}
+}
+
+func TestAuthDoctorPayloadAndReadOnly(t *testing.T) {
+	doctor := authDoctorPayload("prod", config.Config{
+		BaseURL:      "https://stack.grafana.net",
+		Token:        "token",
+		TokenBackend: "keyring",
+	})
+	if doctor["authenticated"] != true {
+		t.Fatalf("expected authenticated doctor payload, got %+v", doctor)
+	}
+	if len(doctor["missing"].([]string)) == 0 {
+		t.Fatalf("expected missing capabilities for partial config")
+	}
+	if len(doctor["capabilities"].([]map[string]any)) != 9 {
+		t.Fatalf("expected capability matrix, got %+v", doctor["capabilities"])
+	}
+	if doctor["oncall_url"] != "" {
+		t.Fatalf("expected empty oncall url in partial doctor payload, got %+v", doctor)
+	}
+
+	if err := enforceReadOnly([]string{"dashboards", "create", "--title", "Ops"}); err == nil {
+		t.Fatalf("expected read-only enforcement for dashboard create")
+	}
+	if err := enforceConfirmation([]string{"auth", "logout"}); err == nil {
+		t.Fatalf("expected confirmation enforcement for auth logout")
+	}
+	if err := enforceConfirmation([]string{"dashboards", "delete", "--uid", "ops"}); err == nil {
+		t.Fatalf("expected confirmation enforcement for dashboard delete")
+	}
+	if err := enforceConfirmation([]string{"api", "POST", "/api/test"}); err == nil {
+		t.Fatalf("expected confirmation enforcement for api POST")
+	}
+	if err := enforceConfirmation([]string{"api", "GET", "/api/test"}); err != nil {
+		t.Fatalf("expected api GET to bypass confirmation: %v", err)
+	}
+	if err := enforceConfirmation([]string{"dashboards", "delete", "--help"}); err != nil {
+		t.Fatalf("expected help to bypass confirmation: %v", err)
+	}
+	if err := enforceReadOnly([]string{"api", "POST", "/api/test"}); err == nil {
+		t.Fatalf("expected read-only enforcement for api POST")
+	}
+	if err := enforceReadOnly([]string{"api", "GET", "/api/test"}); err != nil {
+		t.Fatalf("expected api GET to be allowed in read-only mode: %v", err)
+	}
+	if err := enforceReadOnly([]string{"dashboards", "get", "--help"}); err != nil {
+		t.Fatalf("expected help to bypass read-only enforcement: %v", err)
+	}
+
+	store := &fakeStore{cfg: config.Config{Token: "token"}}
+	client := &fakeClient{rawResult: map[string]any{"ok": true}}
+	app, _, errOut := newTestApp(store, client)
+	if code := app.Run(context.Background(), []string{"--read-only", "dashboards", "create", "--title", "Ops"}); code != 1 {
+		t.Fatalf("expected read-only dashboards create failure")
+	}
+	if !strings.Contains(errOut.String(), "blocked by --read-only") {
+		t.Fatalf("expected read-only error, got %q", errOut.String())
+	}
+	errOut.Reset()
+	if code := app.Run(context.Background(), []string{"--read-only", "api", "GET", "/api/test"}); code != 0 {
+		t.Fatalf("expected read-only api GET success, err=%q", errOut.String())
+	}
+	errOut.Reset()
+	if code := app.Run(context.Background(), []string{"dashboards", "delete", "--uid", "ops"}); code != 1 {
+		t.Fatalf("expected confirmation failure for dashboard delete")
+	}
+	if !strings.Contains(errOut.String(), "requires --yes") {
+		t.Fatalf("expected --yes error, got %q", errOut.String())
+	}
+}
+
+func TestAgentEnvelopeAndTableOutput(t *testing.T) {
+	store := &fakeStore{cfg: config.Config{Token: "token"}}
+	client := &fakeClient{
+		searchDashResult: []any{map[string]any{"uid": "ops"}},
+		listDSResult:     []any{map[string]any{"name": "loki", "type": "loki"}},
+	}
+	app, out, errOut := newTestApp(store, client)
+
+	if code := app.Run(context.Background(), []string{"--agent", "dashboards", "list", "--limit", "1"}); code != 0 {
+		t.Fatalf("agent envelope should succeed: %s", errOut.String())
+	}
+	envelope := decodeJSON(t, out.String())
+	if envelope["status"] != "success" {
+		t.Fatalf("expected success envelope, got %+v", envelope)
+	}
+	metadata := envelope["metadata"].(map[string]any)
+	if metadata["command"] != "dashboards list" {
+		t.Fatalf("expected command metadata, got %+v", metadata)
+	}
+	if metadata["truncated"] != true || metadata["count"] != float64(1) {
+		t.Fatalf("expected truncation metadata, got %+v", metadata)
+	}
+	if metadata["next_action"] == "" {
+		t.Fatalf("expected next action guidance, got %+v", metadata)
+	}
+
+	out.Reset()
+	if code := app.Run(context.Background(), []string{"--output", "table", "datasources", "list"}); code != 0 {
+		t.Fatalf("table output should succeed: %s", errOut.String())
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected table header and row, got %q", out.String())
+	}
+	if !strings.Contains(lines[0], "name") || !strings.Contains(lines[0], "type") {
+		t.Fatalf("expected table header, got %q", lines[0])
+	}
+	if !strings.Contains(lines[1], "loki") {
+		t.Fatalf("expected datasource row, got %q", lines[1])
+	}
+}
+
+func TestTimeNormalizationHelpers(t *testing.T) {
+	now := time.Date(2026, 3, 6, 14, 0, 0, 0, time.UTC)
+	if got := normalizeTimeValue(now, "now"); got != "2026-03-06T14:00:00Z" {
+		t.Fatalf("unexpected now normalization: %s", got)
+	}
+	if got := normalizeTimeValue(now, "30m"); got != "2026-03-06T13:30:00Z" {
+		t.Fatalf("unexpected 30m normalization: %s", got)
+	}
+	if got := normalizeTimeValue(now, "now-2h"); got != "2026-03-06T12:00:00Z" {
+		t.Fatalf("unexpected now-2h normalization: %s", got)
+	}
+	if got := normalizeTimeValue(now, "2026-03-06T11:00:00Z"); got != "2026-03-06T11:00:00Z" {
+		t.Fatalf("unexpected RFC3339 normalization: %s", got)
+	}
+	if got := normalizeTimeValue(now, "1700000000"); got != "1700000000" {
+		t.Fatalf("expected unix timestamp passthrough, got %s", got)
+	}
+	start, end := normalizeTimeRange(now, "", "", time.Hour)
+	if start != "2026-03-06T13:00:00Z" || end != "2026-03-06T14:00:00Z" {
+		t.Fatalf("unexpected default range: start=%s end=%s", start, end)
+	}
+	start, end = normalizeTimeRange(now, "", "2026-03-06T10:00:00Z", time.Hour)
+	if start != "2026-03-06T09:00:00Z" || end != "2026-03-06T10:00:00Z" {
+		t.Fatalf("unexpected anchored range: start=%s end=%s", start, end)
+	}
+
+	if duration, ok := parseRelativeDuration("5 minutes"); !ok || duration != 5*time.Minute {
+		t.Fatalf("expected 5 minute relative duration, got %v ok=%v", duration, ok)
+	}
+	if _, ok := parseRelativeDuration("garbage"); ok {
+		t.Fatalf("unexpected parse success for invalid duration")
+	}
+}
+
+func TestDiscoveryAndRenderHelpersCoverage(t *testing.T) {
+	if syntax := discoveryQuerySyntax([]string{"runtime", "traces"}); len(syntax) != 1 || syntax["traces"] == "" {
+		t.Fatalf("expected traces-only syntax, got %+v", syntax)
+	}
+	if syntax := discoveryQuerySyntax([]string{"dashboards"}); syntax != nil {
+		t.Fatalf("expected no query syntax for dashboards, got %+v", syntax)
+	}
+
+	withOptional := fullCommandPayload(discoveryCommand{
+		Name:            "x",
+		Description:     "desc",
+		ReadOnly:        true,
+		OutputShape:     `{"ok":true}`,
+		Examples:        []string{"grafana x"},
+		RelatedCommands: []string{"schema"},
+	}, nil)
+	if withOptional["output_shape"] == "" || len(withOptional["examples"].([]string)) != 1 {
+		t.Fatalf("expected optional fields in full payload, got %+v", withOptional)
+	}
+	withoutOptional := fullCommandPayload(discoveryCommand{Name: "y", Description: "desc", ReadOnly: true}, nil)
+	if _, ok := withoutOptional["output_shape"]; ok {
+		t.Fatalf("did not expect output shape in sparse full payload")
+	}
+
+	if _, ok := findDiscoveryCommand(discoveryCatalog(), []string{"runtime", "missing"}); ok {
+		t.Fatalf("unexpected discovery match for missing child")
+	}
+	if _, ok := findDiscoveryCommand(discoveryCatalog(), nil); ok {
+		t.Fatalf("unexpected discovery match for empty path")
+	}
+	if len(discoveryPathFromArgs(nil)) != 0 {
+		t.Fatalf("expected empty discovery path for nil args")
+	}
+	if len(discoveryPathFromArgs([]string{"--help"})) != 0 {
+		t.Fatalf("expected empty discovery path for help-only args")
+	}
+
+	if meta := withCommandMetadata(nil, "runtime logs query"); meta.Command != "runtime logs query" {
+		t.Fatalf("expected command metadata on nil input, got %+v", meta)
+	}
+	if meta := collectionMetadata("", "scalar", 0, ""); meta != nil {
+		t.Fatalf("expected nil metadata for scalar payload with no hints, got %+v", meta)
+	}
+	if count, ok := inferMetadataCount(map[string]any{"data": map[string]any{"results": []any{1, 2}}}); !ok || count != 2 {
+		t.Fatalf("expected nested metadata count, got count=%d ok=%v", count, ok)
+	}
+	if _, ok := inferMetadataCount("scalar"); ok {
+		t.Fatalf("unexpected metadata count for scalar payload")
+	}
+
+	var out strings.Builder
+	if err := renderTable(&out, []any{}); err != nil {
+		t.Fatalf("expected empty table render to succeed: %v", err)
+	}
+	if strings.TrimSpace(out.String()) != "No rows" {
+		t.Fatalf("unexpected empty table output: %q", out.String())
+	}
+	if rows := rowsForTable(map[string]any{"items": []any{map[string]any{"id": 1, "attributes": map[string]any{"name": "ops"}}}}); len(rows) != 1 || rows[0]["attributes.name"] != "ops" {
+		t.Fatalf("expected flattened rows, got %+v", rows)
+	}
+	if rows := rowsForTable(map[string]any{"data": []any{map[string]any{"id": 2}}}); len(rows) != 1 || rows[0]["id"] != 2 {
+		t.Fatalf("expected nested data rows, got %+v", rows)
+	}
+	if rows := rowsForTable(map[string]any{"name": "ops"}); len(rows) != 1 || rows[0]["name"] != "ops" {
+		t.Fatalf("expected single object row, got %+v", rows)
+	}
+	if rows := rowsForTable("scalar"); rows != nil {
+		t.Fatalf("expected nil rows for scalar payload, got %+v", rows)
+	}
+	if flattened := flattenTableRow(map[string]any{"a": map[string]any{"b": "c"}}, ""); flattened["a.b"] != "c" {
+		t.Fatalf("expected flattened nested row, got %+v", flattened)
+	}
+	if got := tableCell(nil); got != "" {
+		t.Fatalf("unexpected nil cell: %q", got)
+	}
+	if got := tableCell("ops"); got != "ops" {
+		t.Fatalf("unexpected string cell: %q", got)
+	}
+	if got := tableCell(true); got != "true" {
+		t.Fatalf("unexpected bool cell: %q", got)
+	}
+	if got := tableCell(false); got != "false" {
+		t.Fatalf("unexpected false cell: %q", got)
+	}
+	if got := tableCell(3); got != "3" {
+		t.Fatalf("unexpected numeric cell: %q", got)
+	}
+	if got := tableCell([]any{1, 2}); got != "[2 items]" {
+		t.Fatalf("unexpected array cell: %q", got)
+	}
+	if got := tableCell(map[string]any{"x": 1}); got != `{"x":1}` {
+		t.Fatalf("unexpected object cell: %q", got)
+	}
+	if got := tableCell(func() {}); !strings.Contains(got, "0x") {
+		t.Fatalf("expected fmt fallback for unsupported value, got %q", got)
+	}
+
+	for _, tc := range []struct {
+		value string
+		want  time.Duration
+	}{
+		{"5s", 5 * time.Second},
+		{"2hours", 2 * time.Hour},
+		{"3days", 72 * time.Hour},
+		{"1week", 7 * 24 * time.Hour},
+		{"-5m", 5 * time.Minute},
+	} {
+		if got, ok := parseRelativeDuration(tc.value); !ok || got != tc.want {
+			t.Fatalf("unexpected duration for %s: got=%v ok=%v", tc.value, got, ok)
+		}
+	}
+	if _, ok := parseRelativeDuration("999999999999999999999h"); ok {
+		t.Fatalf("expected parse failure for overflowing duration")
+	}
+}
+
+func TestAdditionalCoveragePaths(t *testing.T) {
+	unauthenticatedDoctor := authDoctorPayload("default", config.Config{})
+	if unauthenticatedDoctor["authenticated"] != false {
+		t.Fatalf("expected unauthenticated doctor payload, got %+v", unauthenticatedDoctor)
+	}
+	if len(unauthenticatedDoctor["suggestions"].([]string)) == 0 {
+		t.Fatalf("expected auth suggestions for unauthenticated payload")
+	}
+
+	if err := enforceReadOnly(nil); err != nil {
+		t.Fatalf("expected nil args to bypass read-only enforcement: %v", err)
+	}
+	if err := enforceConfirmation(nil); err != nil {
+		t.Fatalf("expected nil args to bypass confirmation enforcement: %v", err)
+	}
+	if err := enforceReadOnly([]string{"api"}); err != nil {
+		t.Fatalf("expected api command without method to bypass enforcement: %v", err)
+	}
+	if err := enforceConfirmation([]string{"api"}); err != nil {
+		t.Fatalf("expected api command without method to bypass confirmation enforcement: %v", err)
+	}
+	if err := enforceReadOnly([]string{"dashboards", "get", "--uid", "ops"}); err != nil {
+		t.Fatalf("expected read-only command to be allowed: %v", err)
+	}
+	if err := enforceConfirmation([]string{"dashboards", "get", "--uid", "ops"}); err != nil {
+		t.Fatalf("expected non-destructive command to bypass confirmation: %v", err)
+	}
+	if err := enforceReadOnly([]string{"unknown"}); err != nil {
+		t.Fatalf("expected unknown command path to bypass read-only enforcement: %v", err)
+	}
+	if err := enforceConfirmation([]string{"unknown"}); err != nil {
+		t.Fatalf("expected unknown command path to bypass confirmation enforcement: %v", err)
+	}
+
+	store := &fakeStore{}
+	app, out, _ := newTestApp(store, &fakeClient{})
+	if err := app.emitWithMetadata(globalOptions{Agent: true}, []any{map[string]any{"id": 1}}, nil); err != nil {
+		t.Fatalf("expected emitWithMetadata to build metadata from nil meta, got %v", err)
+	}
+	nilMetaEnvelope := decodeJSON(t, out.String())
+	if nilMetaEnvelope["metadata"].(map[string]any)["count"] != float64(1) {
+		t.Fatalf("expected inferred count from nil meta, got %+v", nilMetaEnvelope)
+	}
+
+	out.Reset()
+	if err := app.emitWithMetadata(globalOptions{Agent: true}, []any{map[string]any{"id": 1}}, &responseMetadata{}); err != nil {
+		t.Fatalf("expected emitWithMetadata to infer counts, got %v", err)
+	}
+	envelope := decodeJSON(t, out.String())
+	if envelope["metadata"].(map[string]any)["count"] != float64(1) {
+		t.Fatalf("expected inferred count, got %+v", envelope)
+	}
+
+	out.Reset()
+	if err := app.emitHelp(globalOptions{}, []string{"missing"}, true); err == nil {
+		t.Fatalf("expected emitHelp to fail for missing path")
+	}
+
+	out.Reset()
+	if err := renderTable(out, map[string]any{"name": "ops", "enabled": true}); err != nil {
+		t.Fatalf("expected object table render to succeed: %v", err)
+	}
+	if !strings.Contains(out.String(), "name") || !strings.Contains(out.String(), "ops") {
+		t.Fatalf("unexpected object table render: %q", out.String())
+	}
+
+	if err := renderTable(&failWriter{failAfter: 0}, []any{}); err == nil {
+		t.Fatalf("expected renderTable empty write failure")
+	}
+	if err := renderTable(&failWriter{failAfter: 0}, map[string]any{"name": "ops"}); err == nil {
+		t.Fatalf("expected renderTable header write failure")
+	}
+	if err := renderTable(&failWriter{failAfter: 1}, map[string]any{"name": "ops"}); err == nil {
+		t.Fatalf("expected renderTable row write failure")
+	}
+}
+
+func TestNoArgDiscoveryPaths(t *testing.T) {
+	store := &fakeContextStore{
+		current: "default",
+		cfgs:    map[string]config.Config{"default": {}},
+	}
+	app, out, errOut := newTestApp(store, &fakeClient{})
+
+	for _, args := range [][]string{
+		{"auth"},
+		{"context"},
+		{"config"},
+		{"api"},
+		{"cloud"},
+		{"dashboards"},
+		{"datasources"},
+		{"folders"},
+		{"annotations"},
+		{"alerting"},
+		{"query-history"},
+		{"slo"},
+		{"irm"},
+		{"oncall"},
+		{"assistant"},
+		{"runtime"},
+		{"aggregate"},
+		{"incident"},
+		{"agent"},
+	} {
+		out.Reset()
+		errOut.Reset()
+		if code := app.Run(context.Background(), args); code != 0 {
+			t.Fatalf("expected discovery help for %v, err=%s", args, errOut.String())
+		}
+		resp := decodeJSON(t, out.String())
+		if _, ok := resp["commands"]; !ok {
+			t.Fatalf("expected discovery commands for %v, got %+v", args, resp)
+		}
+	}
+}
+
+func TestQueryHistoryAndSLOCommands(t *testing.T) {
+	store := &fakeStore{cfg: config.Config{Token: "token"}}
+	client := &fakeClient{
+		rawResult: map[string]any{
+			"result": map[string]any{
+				"queryHistory": []any{
+					map[string]any{"uid": "qh-1", "datasourceUid": "loki-uid"},
+					map[string]any{"uid": "qh-2", "datasourceUid": "prom-uid"},
+				},
+				"totalCount": 3,
+			},
+		},
+	}
+	app, out, errOut := newTestApp(store, client)
+
+	if code := app.Run(context.Background(), []string{"--agent", "query-history", "list", "--datasource-uid", "loki-uid,prom-uid", "--search", "checkout", "--starred", "--sort", "time-asc", "--page", "2", "--limit", "2", "--from", "30m", "--to", "now"}); code != 0 {
+		t.Fatalf("query-history list should succeed: %s", errOut.String())
+	}
+	if client.rawMethod != "GET" || !strings.HasPrefix(client.rawPath, "/api/query-history?") {
+		t.Fatalf("unexpected query-history request: method=%s path=%s", client.rawMethod, client.rawPath)
+	}
+	for _, fragment := range []string{
+		"datasourceUid=loki-uid",
+		"datasourceUid=prom-uid",
+		"searchString=checkout",
+		"onlyStarred=true",
+		"sort=time-asc",
+		"page=2",
+		"limit=2",
+		"from=" + normalizeQueryHistoryBound(app.Now(), "30m"),
+		"to=" + normalizeQueryHistoryBound(app.Now(), "now"),
+	} {
+		if !strings.Contains(client.rawPath, fragment) {
+			t.Fatalf("expected %q in query-history path %q", fragment, client.rawPath)
+		}
+	}
+	queryEnvelope := decodeJSON(t, out.String())
+	queryMeta := queryEnvelope["metadata"].(map[string]any)
+	if queryMeta["count"] != float64(2) || queryMeta["truncated"] != true {
+		t.Fatalf("expected query-history metadata, got %+v", queryMeta)
+	}
+	if queryMeta["next_action"] == "" {
+		t.Fatalf("expected query-history next action, got %+v", queryMeta)
+	}
+
+	out.Reset()
+	client.rawResult = []any{
+		map[string]any{"name": "Checkout Availability", "description": "Success budget"},
+		map[string]any{"name": "Payments Availability", "description": "Payments budget"},
+		map[string]any{"name": "Checkout Latency", "description": "Latency objective"},
+	}
+	if code := app.Run(context.Background(), []string{"--agent", "slo", "list", "--query", "checkout", "--limit", "1"}); code != 0 {
+		t.Fatalf("slo list should succeed: %s", errOut.String())
+	}
+	if client.rawPath != "/api/plugins/grafana-slo-app/resources/v1/slo" {
+		t.Fatalf("unexpected slo path: %s", client.rawPath)
+	}
+	sloEnvelope := decodeJSON(t, out.String())
+	sloMeta := sloEnvelope["metadata"].(map[string]any)
+	if sloMeta["count"] != float64(2) || sloMeta["truncated"] != true {
+		t.Fatalf("expected slo metadata, got %+v", sloMeta)
+	}
+	data := sloEnvelope["data"].([]any)
+	if len(data) != 1 || data[0].(map[string]any)["name"] != "Checkout Availability" {
+		t.Fatalf("expected filtered slo data, got %+v", data)
+	}
+
+	if code := app.Run(context.Background(), []string{"query-history", "bad"}); code != 1 {
+		t.Fatalf("query-history bad subcommand should fail")
+	}
+	if code := app.Run(context.Background(), []string{"query-history", "list", "--sort", "bad"}); code != 1 {
+		t.Fatalf("query-history invalid sort should fail")
+	}
+	if code := app.Run(context.Background(), []string{"query-history", "list", "--limit", "0"}); code != 1 {
+		t.Fatalf("query-history invalid limit should fail")
+	}
+	if code := app.Run(context.Background(), []string{"query-history", "list", "--page", "0"}); code != 1 {
+		t.Fatalf("query-history invalid page should fail")
+	}
+	if code := app.Run(context.Background(), []string{"query-history", "list", "--bad"}); code != 1 {
+		t.Fatalf("query-history parse failure should fail")
+	}
+	if code := app.Run(context.Background(), []string{"slo", "bad"}); code != 1 {
+		t.Fatalf("slo bad subcommand should fail")
+	}
+	if code := app.Run(context.Background(), []string{"slo", "list", "--limit", "0"}); code != 1 {
+		t.Fatalf("slo invalid limit should fail")
+	}
+	if code := app.Run(context.Background(), []string{"slo", "list", "--bad"}); code != 1 {
+		t.Fatalf("slo parse failure should fail")
+	}
+}
+
+func TestIRMAndOnCallCommands(t *testing.T) {
+	store := &fakeStore{cfg: config.Config{Token: "token", BaseURL: "https://stack.grafana.net", OnCallURL: "https://oncall.grafana.net"}}
+	client := &fakeClient{
+		rawResponses: map[string]any{
+			"/api/plugins/grafana-irm-app/resources/api/v1/IncidentsService.QueryIncidentPreviews": map[string]any{
+				"results": []any{
+					map[string]any{"incident": map[string]any{"title": "Checkout latency", "id": "inc-1"}},
+					map[string]any{"incident": map[string]any{"title": "Payments latency", "id": "inc-2"}},
+				},
+			},
+			"/api/v1/schedules/": map[string]any{
+				"count": 2,
+				"next":  "https://oncall.grafana.net/api/v1/schedules/?page=2",
+				"results": []any{
+					map[string]any{"name": "Primary Checkout", "team": map[string]any{"name": "Checkout"}},
+					map[string]any{"name": "Primary Payments", "team": map[string]any{"name": "Payments"}},
+				},
+			},
+		},
+	}
+	out := &strings.Builder{}
+	errOut := &strings.Builder{}
+	app := NewApp(store)
+	app.Out = out
+	app.Err = errOut
+	app.Now = func() time.Time { return time.Date(2026, 3, 5, 15, 4, 0, 0, time.UTC) }
+	var clientConfigs []config.Config
+	app.NewClient = func(cfg config.Config) APIClient {
+		clientConfigs = append(clientConfigs, cfg)
+		return client
+	}
+
+	if code := app.Run(context.Background(), []string{"--agent", "irm", "incidents", "list", "--query", "checkout", "--limit", "2", "--order-field", "updatedAt", "--order-direction", "asc"}); code != 0 {
+		t.Fatalf("irm incidents list should succeed: %s", errOut.String())
+	}
+	if client.rawMethod != "POST" || client.rawPath != "/api/plugins/grafana-irm-app/resources/api/v1/IncidentsService.QueryIncidentPreviews" {
+		t.Fatalf("unexpected irm request: method=%s path=%s", client.rawMethod, client.rawPath)
+	}
+	body := client.rawBody.(map[string]any)["query"].(map[string]any)
+	if body["limit"] != 2 || body["queryString"] != "checkout" {
+		t.Fatalf("unexpected irm request body: %+v", body)
+	}
+	orderBy := body["orderBy"].(map[string]any)
+	if orderBy["field"] != "updatedAt" || orderBy["direction"] != "asc" {
+		t.Fatalf("unexpected irm orderBy: %+v", orderBy)
+	}
+	irmEnvelope := decodeJSON(t, out.String())
+	irmMeta := irmEnvelope["metadata"].(map[string]any)
+	if irmMeta["command"] != "irm incidents list" || irmMeta["count"] != float64(2) {
+		t.Fatalf("unexpected irm metadata: %+v", irmMeta)
+	}
+
+	out.Reset()
+	errOut.Reset()
+	if code := app.Run(context.Background(), []string{"--agent", "oncall", "schedules", "list", "--query", "checkout", "--limit", "1"}); code != 0 {
+		t.Fatalf("oncall schedules list should succeed: %s", errOut.String())
+	}
+	if client.rawMethod != "GET" || client.rawPath != "/api/v1/schedules/" {
+		t.Fatalf("unexpected oncall request: method=%s path=%s", client.rawMethod, client.rawPath)
+	}
+	if len(clientConfigs) < 2 || clientConfigs[len(clientConfigs)-1].BaseURL != "https://oncall.grafana.net" {
+		t.Fatalf("expected oncall client to use oncall base URL, got %+v", clientConfigs)
+	}
+	oncallEnvelope := decodeJSON(t, out.String())
+	oncallMeta := oncallEnvelope["metadata"].(map[string]any)
+	if oncallMeta["command"] != "oncall schedules list" || oncallMeta["count"] != float64(1) || oncallMeta["truncated"] != true {
+		t.Fatalf("unexpected oncall metadata: %+v", oncallMeta)
+	}
+	oncallData := oncallEnvelope["data"].(map[string]any)["results"].([]any)
+	if len(oncallData) != 1 || oncallData[0].(map[string]any)["name"] != "Primary Checkout" {
+		t.Fatalf("unexpected oncall payload: %+v", oncallData)
+	}
+
+	for _, args := range [][]string{
+		{"irm", "bad"},
+		{"irm", "incidents", "list", "--limit", "0"},
+		{"irm", "incidents", "list", "--order-direction", "sideways"},
+		{"irm", "incidents", "list", "--bad"},
+		{"oncall", "bad"},
+		{"oncall", "schedules", "list", "--limit", "0"},
+		{"oncall", "schedules", "list", "--bad"},
+	} {
+		if code := app.Run(context.Background(), args); code != 1 {
+			t.Fatalf("expected failure for %v", args)
 		}
 	}
 }
@@ -979,8 +1852,12 @@ func TestAssistantCommands(t *testing.T) {
 		t.Fatalf("unexpected assistant skills response")
 	}
 
-	if code := app.Run(context.Background(), []string{"assistant"}); code != 1 {
-		t.Fatalf("assistant usage should fail")
+	out.Reset()
+	if code := app.Run(context.Background(), []string{"assistant"}); code != 0 {
+		t.Fatalf("assistant help should succeed")
+	}
+	if _, ok := decodeJSON(t, out.String())["commands"]; !ok {
+		t.Fatalf("expected assistant discovery output")
 	}
 	if code := app.Run(context.Background(), []string{"assistant", "chat"}); code != 1 {
 		t.Fatalf("assistant chat missing prompt should fail")
@@ -1006,8 +1883,26 @@ func TestRuntimeAggregateIncidentAgent(t *testing.T) {
 	store := &fakeStore{cfg: config.Config{Token: "token"}}
 	client := &fakeClient{
 		metricsResult: map[string]any{"m": 1},
-		logsResult:    map[string]any{"l": 1},
-		tracesResult:  map[string]any{"t": 1},
+		logsResult: map[string]any{
+			"data": map[string]any{
+				"result": []any{
+					map[string]any{
+						"stream": map[string]any{"app": "checkout", "level": "error"},
+						"values": []any{[]any{"1", "error"}, []any{"2", "timeout"}},
+					},
+					map[string]any{
+						"stream": map[string]any{"app": "payments"},
+						"values": []any{[]any{"3", "error"}},
+					},
+				},
+			},
+		},
+		tracesResult: map[string]any{
+			"traces": []any{
+				map[string]any{"traceID": "t-1", "rootServiceName": "checkout", "rootTraceName": "GET /checkout"},
+				map[string]any{"traceID": "t-2", "rootServiceName": "payments", "rootTraceName": "POST /charge"},
+			},
+		},
 		aggregateResult: grafana.AggregateSnapshot{
 			Metrics: map[string]any{"data": map[string]any{"result": []any{1, 2}}},
 			Logs:    map[string]any{"data": map[string]any{"result": []any{1}}},
@@ -1020,11 +1915,27 @@ func TestRuntimeAggregateIncidentAgent(t *testing.T) {
 	if code := app.Run(context.Background(), []string{"runtime", "metrics", "query", "--expr", "up"}); code != 0 {
 		t.Fatalf("runtime metrics failed: %s", errOut.String())
 	}
-	if code := app.Run(context.Background(), []string{"runtime"}); code != 1 {
-		t.Fatalf("runtime usage should fail")
+	if client.metricsExpr != "up" || client.metricsStep != "30s" {
+		t.Fatalf("unexpected metrics request capture: %+v", client)
+	}
+	if _, err := time.Parse(time.RFC3339, client.metricsStart); err != nil {
+		t.Fatalf("expected normalized runtime metrics start, got %q", client.metricsStart)
+	}
+	if _, err := time.Parse(time.RFC3339, client.metricsEnd); err != nil {
+		t.Fatalf("expected normalized runtime metrics end, got %q", client.metricsEnd)
+	}
+	out.Reset()
+	if code := app.Run(context.Background(), []string{"runtime"}); code != 0 {
+		t.Fatalf("runtime help should succeed")
+	}
+	if _, ok := decodeJSON(t, out.String())["commands"]; !ok {
+		t.Fatalf("expected runtime discovery output")
 	}
 	if code := app.Run(context.Background(), []string{"runtime", "metrics", "bad"}); code != 1 {
 		t.Fatalf("runtime metrics bad verb should fail")
+	}
+	if code := app.Run(context.Background(), []string{"runtime", "metrics"}); code != 1 {
+		t.Fatalf("runtime metrics missing verb should fail")
 	}
 	if code := app.Run(context.Background(), []string{"runtime", "logs", "bad"}); code != 1 {
 		t.Fatalf("runtime logs bad verb should fail")
@@ -1044,11 +1955,51 @@ func TestRuntimeAggregateIncidentAgent(t *testing.T) {
 	if code := app.Run(context.Background(), []string{"runtime", "logs", "query", "--query", "{}"}); code != 0 {
 		t.Fatalf("runtime logs failed")
 	}
+	if client.logsQuery != "{}" || client.logsLimit != 200 {
+		t.Fatalf("unexpected logs request capture: %+v", client)
+	}
+	if _, err := time.Parse(time.RFC3339, client.logsStart); err != nil {
+		t.Fatalf("expected normalized runtime logs start, got %q", client.logsStart)
+	}
+	if _, err := time.Parse(time.RFC3339, client.logsEnd); err != nil {
+		t.Fatalf("expected normalized runtime logs end, got %q", client.logsEnd)
+	}
+	out.Reset()
+	if code := app.Run(context.Background(), []string{"runtime", "logs", "aggregate", "--query", "{}"}); code != 0 {
+		t.Fatalf("runtime logs aggregate failed")
+	}
+	logSummary := decodeJSON(t, out.String())
+	if logSummary["streams"].(float64) != 2 || logSummary["entries"].(float64) != 3 {
+		t.Fatalf("unexpected logs aggregate summary: %+v", logSummary)
+	}
 	if code := app.Run(context.Background(), []string{"runtime", "traces", "search", "--query", "{}"}); code != 0 {
 		t.Fatalf("runtime traces failed")
 	}
+	if client.tracesQuery != "{}" || client.tracesLimit != 200 {
+		t.Fatalf("unexpected traces request capture: %+v", client)
+	}
+	if _, err := time.Parse(time.RFC3339, client.tracesStart); err != nil {
+		t.Fatalf("expected normalized runtime traces start, got %q", client.tracesStart)
+	}
+	if _, err := time.Parse(time.RFC3339, client.tracesEnd); err != nil {
+		t.Fatalf("expected normalized runtime traces end, got %q", client.tracesEnd)
+	}
+	out.Reset()
+	if code := app.Run(context.Background(), []string{"runtime", "traces", "aggregate", "--query", "{}"}); code != 0 {
+		t.Fatalf("runtime traces aggregate failed")
+	}
+	traceSummary := decodeJSON(t, out.String())
+	if traceSummary["trace_matches"].(float64) != 2 {
+		t.Fatalf("unexpected traces aggregate summary: %+v", traceSummary)
+	}
 	if code := app.Run(context.Background(), []string{"runtime", "metrics", "query"}); code != 1 {
 		t.Fatalf("missing expr should fail")
+	}
+	if code := app.Run(context.Background(), []string{"runtime", "logs", "aggregate"}); code != 1 {
+		t.Fatalf("logs aggregate should require --query")
+	}
+	if code := app.Run(context.Background(), []string{"runtime", "traces", "aggregate"}); code != 1 {
+		t.Fatalf("traces aggregate should require --query")
 	}
 	if code := app.Run(context.Background(), []string{"runtime", "bad", "query"}); code != 1 {
 		t.Fatalf("bad runtime command should fail")
@@ -1063,8 +2014,15 @@ func TestRuntimeAggregateIncidentAgent(t *testing.T) {
 	if code := app.Run(context.Background(), []string{"aggregate", "snapshot"}); code != 1 {
 		t.Fatalf("aggregate missing flags should fail")
 	}
-	if code := app.Run(context.Background(), []string{"aggregate"}); code != 1 {
-		t.Fatalf("aggregate usage should fail")
+	if code := app.Run(context.Background(), []string{"aggregate", "bad"}); code != 1 {
+		t.Fatalf("aggregate bad subcommand should fail")
+	}
+	out.Reset()
+	if code := app.Run(context.Background(), []string{"aggregate"}); code != 0 {
+		t.Fatalf("aggregate help should succeed")
+	}
+	if _, ok := decodeJSON(t, out.String())["commands"]; !ok {
+		t.Fatalf("expected aggregate discovery output")
 	}
 	if code := app.Run(context.Background(), []string{"aggregate", "snapshot", "--bad"}); code != 1 {
 		t.Fatalf("aggregate parse should fail")
@@ -1132,6 +2090,67 @@ func TestRequireAuthAndClientErrors(t *testing.T) {
 		t.Fatalf("unexpected auth error: %s", errOut.String())
 	}
 
+	store = &fakeStore{cfg: config.Config{}}
+	client = &fakeClient{}
+	app, _, _ = newTestApp(store, client)
+	if code := app.Run(context.Background(), []string{"query-history", "list"}); code != 1 {
+		t.Fatalf("expected query-history auth error")
+	}
+	store = &fakeStore{cfg: config.Config{Token: "x"}}
+	client = &fakeClient{rawErr: errors.New("query-history fail")}
+	app, _, _ = newTestApp(store, client)
+	if code := app.Run(context.Background(), []string{"query-history", "list"}); code != 1 {
+		t.Fatalf("expected query-history client error")
+	}
+
+	store = &fakeStore{cfg: config.Config{}}
+	client = &fakeClient{}
+	app, _, _ = newTestApp(store, client)
+	if code := app.Run(context.Background(), []string{"slo", "list"}); code != 1 {
+		t.Fatalf("expected slo auth error")
+	}
+	store = &fakeStore{cfg: config.Config{Token: "x"}}
+	client = &fakeClient{rawErr: errors.New("slo fail")}
+	app, _, _ = newTestApp(store, client)
+	if code := app.Run(context.Background(), []string{"slo", "list"}); code != 1 {
+		t.Fatalf("expected slo client error")
+	}
+
+	store = &fakeStore{cfg: config.Config{}}
+	client = &fakeClient{}
+	app, _, _ = newTestApp(store, client)
+	if code := app.Run(context.Background(), []string{"irm", "incidents", "list"}); code != 1 {
+		t.Fatalf("expected irm auth error")
+	}
+	store = &fakeStore{cfg: config.Config{Token: "x"}}
+	client = &fakeClient{rawErr: errors.New("irm fail")}
+	app, _, _ = newTestApp(store, client)
+	if code := app.Run(context.Background(), []string{"irm", "incidents", "list"}); code != 1 {
+		t.Fatalf("expected irm client error")
+	}
+
+	store = &fakeStore{cfg: config.Config{Token: "x"}}
+	client = &fakeClient{}
+	app, _, errOut = newTestApp(store, client)
+	if code := app.Run(context.Background(), []string{"oncall", "schedules", "list"}); code != 1 {
+		t.Fatalf("expected oncall config error")
+	}
+	if !strings.Contains(errOut.String(), "oncall URL is not configured") {
+		t.Fatalf("unexpected oncall config error: %s", errOut.String())
+	}
+	store = &fakeStore{cfg: config.Config{Token: "x", OnCallURL: "https://oncall"}}
+	client = &fakeClient{rawErr: errors.New("oncall fail")}
+	app, _, _ = newTestApp(store, client)
+	if code := app.Run(context.Background(), []string{"oncall", "schedules", "list"}); code != 1 {
+		t.Fatalf("expected oncall client error")
+	}
+	store = &fakeStore{cfg: config.Config{}}
+	client = &fakeClient{}
+	app, _, _ = newTestApp(store, client)
+	if _, err := app.requireOnCallConfig(); err == nil {
+		t.Fatalf("expected requireOnCallConfig auth failure")
+	}
+
 	store = &fakeStore{cfg: config.Config{Token: "x"}}
 	client = &fakeClient{cloudErr: errors.New("cloud fail")}
 	app, _, errOut = newTestApp(store, client)
@@ -1159,7 +2178,7 @@ func TestRequireAuthAndClientErrors(t *testing.T) {
 	if code := app.Run(context.Background(), []string{"dashboards", "get", "--uid", "ops"}); code != 1 {
 		t.Fatalf("expected dashboard get client failure")
 	}
-	if code := app.Run(context.Background(), []string{"dashboards", "delete", "--uid", "ops"}); code != 1 {
+	if code := app.Run(context.Background(), []string{"--yes", "dashboards", "delete", "--uid", "ops"}); code != 1 {
 		t.Fatalf("expected dashboard delete client failure")
 	}
 	if code := app.Run(context.Background(), []string{"dashboards", "versions", "--uid", "ops"}); code != 1 {
@@ -1264,8 +2283,8 @@ func TestAdditionalCommandBranches(t *testing.T) {
 	}
 
 	// agent with no subcommand.
-	if code := app.Run(context.Background(), []string{"agent"}); code != 1 {
-		t.Fatalf("agent usage should fail")
+	if code := app.Run(context.Background(), []string{"agent"}); code != 0 {
+		t.Fatalf("agent help should succeed")
 	}
 }
 
@@ -1463,8 +2482,14 @@ func TestHelpers(t *testing.T) {
 	if inferCollectionCount(map[string]any{"items": []any{1}}) != 1 {
 		t.Fatalf("unexpected map collection count")
 	}
+	if inferCollectionCount(map[string]any{"result": map[string]any{"queryHistory": []any{1}}}) != 1 {
+		t.Fatalf("unexpected nested collection count")
+	}
 	if inferCollectionCount("x") != 0 {
 		t.Fatalf("unexpected fallback count")
+	}
+	if inferCollectionCount(map[string]any{"ignored": []any{1}}) != 0 {
+		t.Fatalf("unexpected collection count for ignored key")
 	}
 
 	if countPath(map[string]any{"a": map[string]any{"b": []any{1, 2}}}, "a", "b") != 2 {
@@ -1506,6 +2531,217 @@ func TestHelpers(t *testing.T) {
 	if parseInt("10", 5) != 10 || parseInt("bad", 5) != 5 {
 		t.Fatalf("unexpected parseInt result")
 	}
+	if minInt(3, 2) != 2 || minInt(1, 2) != 1 {
+		t.Fatalf("unexpected min results")
+	}
+	if appendQuery("/api/test", nil) != "/api/test" {
+		t.Fatalf("expected empty query append to preserve path")
+	}
+	if got := appendQuery("/api/test", url.Values{"q": []string{"x"}}); got != "/api/test?q=x" {
+		t.Fatalf("unexpected query append: %s", got)
+	}
+	if got := normalizeQueryHistoryBound(time.Date(2026, 3, 5, 15, 4, 0, 0, time.UTC), "30m"); got != "1772721240000" {
+		t.Fatalf("unexpected query-history bound normalization: %s", got)
+	}
+	if got := normalizeQueryHistoryBound(time.Date(2026, 3, 5, 15, 4, 0, 0, time.UTC), "1700000000"); got != "1700000000" {
+		t.Fatalf("expected unix passthrough, got %s", got)
+	}
+	if meta := queryHistoryMetadata(map[string]any{"result": map[string]any{"queryHistory": []any{1, 2}, "totalCount": 4}}, 2); meta.Count == nil || *meta.Count != 2 || !meta.Truncated {
+		t.Fatalf("unexpected query-history metadata: %+v", meta)
+	}
+	if meta := queryHistoryMetadata(map[string]any{"result": map[string]any{}}, 1); len(meta.Warnings) != 1 {
+		t.Fatalf("expected query-history warnings, got %+v", meta)
+	}
+	filteredPayload, count, truncated := filterNamedPayload([]any{
+		map[string]any{"name": "Checkout Availability", "description": "Success"},
+		map[string]any{"name": "Payments Availability", "description": "Payments"},
+		map[string]any{"name": "Checkout Latency", "description": "Latency"},
+	}, "checkout", 1, "name", "description")
+	filteredItems := filteredPayload.([]any)
+	if count != 2 || !truncated || len(filteredItems) != 1 {
+		t.Fatalf("unexpected filtered payload result: count=%d truncated=%v payload=%+v", count, truncated, filteredPayload)
+	}
+	payloadMap, count, truncated := filterNamedPayload(map[string]any{"slos": []any{
+		map[string]any{"name": "Checkout", "description": "Budget"},
+	}}, "", 10, "name")
+	if count != 1 || truncated || payloadMap.(map[string]any)["slos"] == nil {
+		t.Fatalf("unexpected wrapped filtered payload: count=%d truncated=%v payload=%+v", count, truncated, payloadMap)
+	}
+	resultsPayload, count, truncated := filterNamedPayload(map[string]any{"results": []any{
+		map[string]any{"name": "Checkout"},
+		map[string]any{"name": "Payments"},
+	}}, "checkout", 10, "name")
+	if count != 1 || truncated || len(resultsPayload.(map[string]any)["results"].([]any)) != 1 {
+		t.Fatalf("unexpected results wrapped filtered payload: count=%d truncated=%v payload=%+v", count, truncated, resultsPayload)
+	}
+	if _, _, ok := collectionPayload("scalar"); ok {
+		t.Fatalf("unexpected collection payload for scalar")
+	}
+	if passthroughPayload, passthroughCount, passthroughTruncated := filterNamedPayload(map[string]any{"other": "value"}, "checkout", 5, "name"); passthroughCount != 0 || passthroughTruncated || passthroughPayload.(map[string]any)["other"] != "value" {
+		t.Fatalf("unexpected passthrough filtered payload: count=%d truncated=%v payload=%+v", passthroughCount, passthroughTruncated, passthroughPayload)
+	}
+	if filteredPayload, count, truncated := filterNamedPayload([]any{"bad", map[string]any{"name": "Checkout"}}, "checkout", 10, "name"); count != 1 || truncated || len(filteredPayload.([]any)) != 1 {
+		t.Fatalf("unexpected mixed filtered payload: count=%d truncated=%v payload=%+v", count, truncated, filteredPayload)
+	}
+	if !matchesAnyField(map[string]any{"name": "Checkout"}, "check", "name") {
+		t.Fatalf("expected matchesAnyField to match")
+	}
+	if !matchesAnyField(map[string]any{"name": "Checkout"}, "", "name") {
+		t.Fatalf("expected empty query to match")
+	}
+	if matchesAnyField(map[string]any{"name": "Checkout"}, "payments", "name") {
+		t.Fatalf("expected matchesAnyField to miss")
+	}
+	if got := collectionAtPath(map[string]any{"data": map[string]any{"result": []any{1, 2}}}, "data", "result"); len(got) != 2 {
+		t.Fatalf("unexpected collectionAtPath result: %+v", got)
+	}
+	if got := collectionAtPath("scalar", "data"); got != nil {
+		t.Fatalf("expected nil collectionAtPath for scalar")
+	}
+	if got, ok := intPath(map[string]any{"result": map[string]any{"totalCount": float64(4)}}, "result", "totalCount"); !ok || got != 4 {
+		t.Fatalf("unexpected intPath result: got=%d ok=%v", got, ok)
+	}
+	if _, ok := intPath("scalar", "x"); ok {
+		t.Fatalf("unexpected intPath success for scalar")
+	}
+	if got, ok := intValue(json.Number("4")); !ok || got != 4 {
+		t.Fatalf("unexpected intValue result: got=%d ok=%v", got, ok)
+	}
+	if got, ok := intValue(int64(6)); !ok || got != 6 {
+		t.Fatalf("unexpected intValue int64 result: got=%d ok=%v", got, ok)
+	}
+	if _, ok := intValue(json.Number("bad")); ok {
+		t.Fatalf("unexpected intValue success for invalid json number")
+	}
+	if _, ok := intValue("bad"); ok {
+		t.Fatalf("unexpected intValue success for string")
+	}
+	if got := firstNonEmptyString(map[string]any{"a": "", "b": "checkout"}, "a", "b"); got != "checkout" {
+		t.Fatalf("unexpected firstNonEmptyString result: %s", got)
+	}
+	if got := firstNonEmptyString(map[string]any{"a": ""}, "missing", "a"); got != "" {
+		t.Fatalf("expected empty firstNonEmptyString result, got %q", got)
+	}
+	if got := sortedSet(map[string]struct{}{"b": {}, "a": {}}); len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Fatalf("unexpected sortedSet result: %+v", got)
+	}
+	logSummary := summarizeLogsResult(map[string]any{"data": map[string]any{"result": []any{
+		"bad",
+		map[string]any{"stream": map[string]any{"app": "checkout"}, "values": []any{1, 2}},
+	}}})
+	if logSummary["streams"].(int) != 1 || logSummary["entries"].(int) != 2 {
+		t.Fatalf("unexpected log summary: %+v", logSummary)
+	}
+	traceSummary := summarizeTracesResult(map[string]any{"data": map[string]any{"traces": []any{
+		"bad",
+		map[string]any{"traceID": "t-1", "rootServiceName": "checkout", "rootTraceName": "GET /checkout"},
+	}}})
+	if traceSummary["trace_matches"].(int) != 1 || traceSummary["services"].([]string)[0] != "checkout" {
+		t.Fatalf("unexpected trace summary: %+v", traceSummary)
+	}
+	if meta := runtimeAggregateMetadata("runtime logs aggregate", 2); meta.Command != "runtime logs aggregate" || meta.Count == nil || *meta.Count != 2 {
+		t.Fatalf("unexpected runtime aggregate metadata: %+v", meta)
+	}
+	if !payloadHasNextPage(map[string]any{"next": "https://next"}) {
+		t.Fatalf("expected payloadHasNextPage to detect next page")
+	}
+	if payloadHasNextPage([]any{1}) {
+		t.Fatalf("expected payloadHasNextPage to ignore non-map payloads")
+	}
+}
+
+func TestAuthInferenceHelpers(t *testing.T) {
+	slug, baseURL, err := normalizeStackIdentifier("https://prod-observability.grafana.net")
+	if err != nil || slug != "prod-observability" || baseURL != "https://prod-observability.grafana.net" {
+		t.Fatalf("unexpected stack identifier parse from url: slug=%s base=%s err=%v", slug, baseURL, err)
+	}
+	slug, baseURL, err = normalizeStackIdentifier("prod-observability.grafana.net")
+	if err != nil || slug != "prod-observability" || baseURL != "https://prod-observability.grafana.net" {
+		t.Fatalf("unexpected stack identifier parse from host: slug=%s base=%s err=%v", slug, baseURL, err)
+	}
+	slug, baseURL, err = normalizeStackIdentifier("prod-observability")
+	if err != nil || slug != "prod-observability" || baseURL != "https://prod-observability.grafana.net" {
+		t.Fatalf("unexpected stack identifier parse from slug: slug=%s base=%s err=%v", slug, baseURL, err)
+	}
+	if _, _, err := normalizeStackIdentifier("https://example.com"); err == nil {
+		t.Fatalf("expected invalid stack host error")
+	}
+	if _, _, err := normalizeStackIdentifier("example.com"); err == nil {
+		t.Fatalf("expected invalid stack host without scheme error")
+	}
+	if _, _, err := normalizeStackIdentifier("https://%"); err == nil {
+		t.Fatalf("expected invalid stack url parse error")
+	}
+	if _, _, err := normalizeStackIdentifier(""); err == nil {
+		t.Fatalf("expected empty stack error")
+	}
+
+	endpoints := inferDatasourceEndpoints([]any{
+		map[string]any{"type": "prometheus", "url": "https://prom"},
+		map[string]any{"type": "loki", "url": "https://logs"},
+		map[string]any{"type": "tempo", "url": "https://traces"},
+	})
+	if endpoints.PrometheusURL != "https://prom" || endpoints.LogsURL != "https://logs" || endpoints.TracesURL != "https://traces" {
+		t.Fatalf("unexpected datasource endpoint inference: %+v", endpoints)
+	}
+	if endpoints := inferDatasourceEndpoints([]any{"bad", map[string]any{"type": "prometheus"}}); endpoints.PrometheusURL != "" {
+		t.Fatalf("expected datasource inference to ignore invalid entries, got %+v", endpoints)
+	}
+	if endpoints := inferDatasourceEndpoints("scalar"); endpoints.PrometheusURL != "" || endpoints.LogsURL != "" || endpoints.TracesURL != "" {
+		t.Fatalf("expected empty datasource inference for scalar payload, got %+v", endpoints)
+	}
+	if oncallURL := inferOnCallURL(map[string]any{"connections": []any{
+		map[string]any{"type": "oncall", "details": map[string]any{"oncallApiUrl": "https://oncall"}},
+	}}); oncallURL != "https://oncall" {
+		t.Fatalf("unexpected oncall url inference: %s", oncallURL)
+	}
+	if oncallURL := inferOnCallURL(map[string]any{"oncallApiUrl": "https://root-oncall"}); oncallURL != "https://root-oncall" {
+		t.Fatalf("unexpected top-level oncall url inference: %s", oncallURL)
+	}
+	if oncallURL := inferOnCallURL(map[string]any{"results": []any{
+		"bad",
+		map[string]any{"type": "oncall", "details": map[string]any{"oncallApiUrl": "https://record-oncall"}},
+	}}); oncallURL != "https://record-oncall" {
+		t.Fatalf("unexpected oncall url inference from record scan: %s", oncallURL)
+	}
+	if oncallURL := inferOnCallURL(map[string]any{"connections": []any{
+		map[string]any{"type": "oncall", "url": "https://fallback-oncall"},
+	}}); oncallURL != "https://fallback-oncall" {
+		t.Fatalf("unexpected oncall fallback url inference: %s", oncallURL)
+	}
+	if oncallURL := inferOnCallURL(map[string]any{"results": []any{
+		map[string]any{"type": "pagerduty", "url": "https://pagerduty"},
+	}}); oncallURL != "" {
+		t.Fatalf("expected empty oncall inference for unrelated payload, got %s", oncallURL)
+	}
+	if oncallURL := inferOnCallURL("scalar"); oncallURL != "" {
+		t.Fatalf("expected empty oncall inference for scalar payload, got %s", oncallURL)
+	}
+	if value := recursiveStringValue(map[string]any{"a": []any{map[string]any{"oncallApiUrl": "https://oncall"}}}, "oncallApiUrl"); value != "https://oncall" {
+		t.Fatalf("unexpected recursive string value: %s", value)
+	}
+	if !containsAny("grafana-oncall", "oncall", "schedules") {
+		t.Fatalf("expected containsAny match")
+	}
+	if containsAny("grafana-runtime", "oncall", "schedules") {
+		t.Fatalf("expected containsAny to miss")
+	}
+
+	app := NewApp(&fakeStore{})
+	fake := &fakeClient{
+		rawResponses: map[string]any{
+			"/api/instances/prod-observability/datasources": []any{map[string]any{"type": "prometheus", "url": "https://prom"}},
+		},
+		rawErrors: map[string]error{
+			"/api/instances/prod-observability/connections": errors.New("connections failed"),
+		},
+	}
+	app.NewClient = func(config.Config) APIClient { return fake }
+	cfg := &config.Config{CloudURL: "https://grafana.com", Token: "token"}
+	warnings := app.applyInferredStackEndpoints(context.Background(), cfg, "prod-observability", "")
+	if len(warnings) != 1 || cfg.PrometheusURL != "https://prom" {
+		t.Fatalf("unexpected inferred stack endpoint warnings or config: warnings=%+v cfg=%+v", warnings, cfg)
+	}
 }
 
 func TestContextAndConfigCommands(t *testing.T) {
@@ -1519,6 +2755,7 @@ func TestContextAndConfigCommands(t *testing.T) {
 				PrometheusURL: "https://prom-default.grafana.net",
 				LogsURL:       "https://logs-default.grafana.net",
 				TracesURL:     "https://traces-default.grafana.net",
+				OnCallURL:     "https://oncall-default.grafana.net",
 				OrgID:         1,
 			},
 			"prod": {
@@ -1528,6 +2765,7 @@ func TestContextAndConfigCommands(t *testing.T) {
 				PrometheusURL: "https://prom-prod.grafana.net",
 				LogsURL:       "https://logs-prod.grafana.net",
 				TracesURL:     "https://traces-prod.grafana.net",
+				OnCallURL:     "https://oncall-prod.grafana.net",
 				OrgID:         2,
 			},
 		},
@@ -1659,7 +2897,7 @@ func TestContextAndConfigCommands(t *testing.T) {
 		t.Fatalf("auth status should succeed: %s", errOut.String())
 	}
 	status := decodeJSON(t, out.String())
-	if status["context"] != "ops" || status["status"] != "authenticated" {
+	if status["context"] != "ops" || status["status"] != "authenticated" || status["capabilities"] == nil {
 		t.Fatalf("unexpected auth status: %+v", status)
 	}
 }
@@ -1903,6 +3141,7 @@ func TestOutputFormattingAndContextHelpers(t *testing.T) {
 				PrometheusURL: "https://prom.grafana.net",
 				LogsURL:       "https://logs.grafana.net",
 				TracesURL:     "https://traces.grafana.net",
+				OnCallURL:     "https://oncall.grafana.net",
 				TokenBackend:  "keyring",
 				OrgID:         7,
 			},
@@ -1970,7 +3209,7 @@ func TestOutputFormattingAndContextHelpers(t *testing.T) {
 	}
 
 	payload := configPayload("default", store.cfgs["default"])
-	if payload["token_backend"] != "keyring" {
+	if payload["token_backend"] != "keyring" || payload["oncall_url"] != "https://oncall.grafana.net" {
 		t.Fatalf("unexpected config payload: %+v", payload)
 	}
 
@@ -1984,6 +3223,7 @@ func TestOutputFormattingAndContextHelpers(t *testing.T) {
 		PrometheusURL: "prom",
 		LogsURL:       "logs",
 		TracesURL:     "traces",
+		OnCallURL:     "oncall",
 		TokenBackend:  "keyring",
 		OrgID:         5,
 	}
@@ -1995,6 +3235,7 @@ func TestOutputFormattingAndContextHelpers(t *testing.T) {
 		"prometheus_url": "prom",
 		"logs-url":       "logs",
 		"traces_url":     "traces",
+		"oncall-url":     "oncall",
 		"org-id":         int64(5),
 		"token-backend":  "keyring",
 	} {
@@ -2018,6 +3259,7 @@ func TestOutputFormattingAndContextHelpers(t *testing.T) {
 		{key: "prom-url", value: "prom", check: func(cfg config.Config) bool { return cfg.PrometheusURL == "prom" }},
 		{key: "logs-url", value: "logs", check: func(cfg config.Config) bool { return cfg.LogsURL == "logs" }},
 		{key: "traces-url", value: "traces", check: func(cfg config.Config) bool { return cfg.TracesURL == "traces" }},
+		{key: "oncall-url", value: "oncall", check: func(cfg config.Config) bool { return cfg.OnCallURL == "oncall" }},
 		{key: "org-id", value: "11", check: func(cfg config.Config) bool { return cfg.OrgID == 11 }},
 	}
 	for _, update := range updates {

--- a/internal/cli/discovery.go
+++ b/internal/cli/discovery.go
@@ -1,0 +1,551 @@
+package cli
+
+import (
+	"errors"
+	"strings"
+)
+
+const cliVersion = "0.1.0"
+
+type discoveryFlag struct {
+	Name        string `json:"name"`
+	Type        string `json:"type,omitempty"`
+	Default     any    `json:"default,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+type discoveryCommand struct {
+	Name            string
+	Description     string
+	ReadOnly        bool
+	Flags           []discoveryFlag
+	Examples        []string
+	OutputShape     string
+	RelatedCommands []string
+	TokenCost       string
+	Subcommands     []discoveryCommand
+}
+
+type discoveryWorkflow struct {
+	Name      string   `json:"name"`
+	Steps     []string `json:"steps"`
+	TokenCost string   `json:"token_cost,omitempty"`
+}
+
+type discoveryTimeFormats struct {
+	Relative []string `json:"relative,omitempty"`
+	Absolute []string `json:"absolute,omitempty"`
+	Examples []string `json:"examples,omitempty"`
+}
+
+func discoveryCatalog() []discoveryCommand {
+	return []discoveryCommand{
+		{
+			Name:        "schema",
+			Description: "Emit the machine-readable discovery schema for the CLI",
+			ReadOnly:    true,
+			Flags: []discoveryFlag{
+				{Name: "--compact", Type: "bool", Default: false, Description: "Return a smaller schema intended for agent discovery loops"},
+			},
+			Examples: []string{
+				"grafana schema --compact",
+				"grafana schema runtime",
+			},
+			OutputShape:     `{"version":"0.1.0","commands":[...]}`,
+			RelatedCommands: []string{"runtime", "incident", "agent"},
+			TokenCost:       "small",
+		},
+		{
+			Name:        "auth",
+			Description: "Authenticate and inspect local Grafana configuration",
+			ReadOnly:    false,
+			Subcommands: []discoveryCommand{
+				{
+					Name:        "login",
+					Description: "Store token and endpoint configuration for the current context",
+					ReadOnly:    false,
+					Flags: []discoveryFlag{
+						{Name: "--token", Type: "string", Description: "Grafana token"},
+						{Name: "--context", Type: "string", Description: "Context name"},
+						{Name: "--stack", Type: "string", Description: "Grafana Cloud stack slug or https://<stack>.grafana.net URL"},
+						{Name: "--cloud-token", Type: "string", Description: "Grafana Cloud API token used only for endpoint discovery"},
+						{Name: "--base-url", Type: "string", Description: "Grafana base URL"},
+						{Name: "--cloud-url", Type: "string", Description: "Grafana Cloud API URL"},
+						{Name: "--prom-url", Type: "string", Description: "Prometheus query URL"},
+						{Name: "--logs-url", Type: "string", Description: "Loki query URL"},
+						{Name: "--traces-url", Type: "string", Description: "Tempo query URL"},
+						{Name: "--oncall-url", Type: "string", Description: "Grafana OnCall API URL"},
+						{Name: "--org-id", Type: "int", Default: 0, Description: "Grafana organization ID"},
+					},
+					Examples: []string{
+						`grafana auth login --token "$GRAFANA_TOKEN" --stack prod-observability`,
+						`grafana auth login --token "$GRAFANA_TOKEN" --stack https://prod-observability.grafana.net`,
+						`grafana auth login --context prod --token "$GRAFANA_TOKEN" --base-url "https://prod.grafana.net"`,
+					},
+					OutputShape:     `{"status":"authenticated","base_url":"https://stack.grafana.net","missing":["oncall_url"]}`,
+					RelatedCommands: []string{"auth status", "auth doctor", "context list"},
+					TokenCost:       "small",
+				},
+				{
+					Name:            "status",
+					Description:     "Show the current authentication status and configured endpoints",
+					ReadOnly:        true,
+					Examples:        []string{"grafana auth status"},
+					OutputShape:     `{"status":"authenticated","capabilities":[{"name":"runtime_logs","ok":true}]}`,
+					RelatedCommands: []string{"auth doctor", "context view"},
+					TokenCost:       "small",
+				},
+				{
+					Name:            "doctor",
+					Description:     "Diagnose missing auth and endpoint configuration by capability",
+					ReadOnly:        true,
+					Examples:        []string{"grafana auth doctor"},
+					OutputShape:     `{"authenticated":true,"capabilities":[{"name":"runtime_logs","ok":false}]}`,
+					RelatedCommands: []string{"auth status", "config set"},
+					TokenCost:       "small",
+				},
+				{
+					Name:            "logout",
+					Description:     "Clear the current context token and persisted auth state",
+					ReadOnly:        false,
+					Examples:        []string{"grafana auth logout"},
+					OutputShape:     `{"status":"logged_out"}`,
+					RelatedCommands: []string{"auth login", "auth status"},
+					TokenCost:       "small",
+				},
+			},
+		},
+		{
+			Name:        "context",
+			Description: "Manage local CLI contexts",
+			ReadOnly:    false,
+			Subcommands: []discoveryCommand{
+				{Name: "list", Description: "List configured contexts", ReadOnly: true, Examples: []string{"grafana context list"}, OutputShape: `[{"name":"prod","current":true}]`, RelatedCommands: []string{"context use", "context view"}, TokenCost: "small"},
+				{Name: "use", Description: "Switch the active context", ReadOnly: false, Examples: []string{"grafana context use prod"}, OutputShape: `{"context":"prod"}`, RelatedCommands: []string{"context list", "context view"}, TokenCost: "small"},
+				{Name: "view", Description: "Show the current context configuration", ReadOnly: true, Examples: []string{"grafana context view"}, OutputShape: `{"context":"default","base_url":"https://..."}`, RelatedCommands: []string{"context list", "config get"}, TokenCost: "small"},
+			},
+		},
+		{
+			Name:        "config",
+			Description: "Inspect and modify persisted CLI configuration",
+			ReadOnly:    false,
+			Subcommands: []discoveryCommand{
+				{Name: "list", Description: "List the config for a context", ReadOnly: true, Flags: []discoveryFlag{{Name: "--context", Type: "string", Description: "Context name"}}, Examples: []string{"grafana config list", "grafana config list --context prod"}, OutputShape: `{"base_url":"https://..."}`, RelatedCommands: []string{"config get", "config set"}, TokenCost: "small"},
+				{Name: "get", Description: "Read one config key", ReadOnly: true, Flags: []discoveryFlag{{Name: "--context", Type: "string", Description: "Context name"}}, Examples: []string{"grafana config get base-url"}, OutputShape: `{"key":"base_url","value":"https://..."}`, RelatedCommands: []string{"config list", "config set"}, TokenCost: "small"},
+				{Name: "set", Description: "Persist one config key", ReadOnly: false, Flags: []discoveryFlag{{Name: "--context", Type: "string", Description: "Context name"}}, Examples: []string{"grafana config set org-id 12"}, OutputShape: `{"org_id":12}`, RelatedCommands: []string{"config get", "auth doctor"}, TokenCost: "small"},
+			},
+		},
+		{
+			Name:        "api",
+			Description: "Call the raw Grafana HTTP API when no dedicated command exists",
+			ReadOnly:    false,
+			Flags: []discoveryFlag{
+				{Name: "--body", Type: "json", Description: "JSON request body"},
+			},
+			Examples: []string{
+				`grafana api GET /api/health`,
+				`grafana api POST /api/dashboards/db --body '{"dashboard":{"title":"Ops"}}'`,
+			},
+			OutputShape:     `{"commit":"abc123","database":"ok"}`,
+			RelatedCommands: []string{"schema", "dashboards list"},
+			TokenCost:       "small",
+		},
+		{
+			Name:        "cloud",
+			Description: "Inspect Grafana Cloud control-plane resources",
+			ReadOnly:    true,
+			Subcommands: []discoveryCommand{
+				{
+					Name:        "stacks",
+					Description: "Inspect Grafana Cloud stacks",
+					ReadOnly:    true,
+					Subcommands: []discoveryCommand{
+						{Name: "list", Description: "List available Grafana Cloud stacks", ReadOnly: true, Examples: []string{"grafana cloud stacks list"}, OutputShape: `{"items":[...]}`, RelatedCommands: []string{"auth doctor", "context list"}, TokenCost: "small"},
+					},
+				},
+			},
+		},
+		{
+			Name:        "dashboards",
+			Description: "Inspect and manage dashboards",
+			ReadOnly:    false,
+			Subcommands: []discoveryCommand{
+				{Name: "list", Description: "Search dashboards by query and tag", ReadOnly: true, Flags: []discoveryFlag{{Name: "--query", Type: "string", Description: "Search text"}, {Name: "--tag", Type: "string", Description: "Tag filter"}, {Name: "--limit", Type: "int", Default: 100, Description: "Maximum dashboards"}}, Examples: []string{"grafana dashboards list --query latency --tag prod"}, OutputShape: `[{"uid":"incident-overview"}]`, RelatedCommands: []string{"dashboards get", "dashboards versions"}, TokenCost: "small"},
+				{Name: "get", Description: "Fetch one dashboard by UID", ReadOnly: true, Flags: []discoveryFlag{{Name: "--uid", Type: "string", Description: "Dashboard UID"}}, Examples: []string{"grafana dashboards get --uid incident-overview"}, OutputShape: `{"dashboard":{"uid":"incident-overview"}}`, RelatedCommands: []string{"dashboards list", "dashboards render"}, TokenCost: "medium"},
+				{Name: "create", Description: "Create a dashboard from flags or JSON", ReadOnly: false, Flags: []discoveryFlag{{Name: "--title", Type: "string", Description: "Dashboard title"}, {Name: "--uid", Type: "string", Description: "Dashboard UID"}, {Name: "--schema-version", Type: "int", Default: 39, Description: "Schema version"}, {Name: "--folder-id", Type: "int", Default: 0, Description: "Folder ID"}, {Name: "--overwrite", Type: "bool", Default: true, Description: "Overwrite existing dashboard"}, {Name: "--tags", Type: "csv", Description: "Comma-separated tags"}, {Name: "--template-json", Type: "json", Description: "Full dashboard JSON"}}, Examples: []string{`grafana dashboards create --title "Incident Overview"`, `grafana dashboards create --template-json '{"title":"Ops","panels":[]}'`}, OutputShape: `{"status":"success","uid":"incident-overview"}`, RelatedCommands: []string{"dashboards get", "dashboards delete"}, TokenCost: "medium"},
+				{Name: "delete", Description: "Delete a dashboard by UID", ReadOnly: false, Flags: []discoveryFlag{{Name: "--uid", Type: "string", Description: "Dashboard UID"}}, Examples: []string{"grafana dashboards delete --uid incident-overview"}, OutputShape: `{"status":"deleted"}`, RelatedCommands: []string{"dashboards get", "dashboards list"}, TokenCost: "small"},
+				{Name: "versions", Description: "List dashboard versions", ReadOnly: true, Flags: []discoveryFlag{{Name: "--uid", Type: "string", Description: "Dashboard UID"}, {Name: "--limit", Type: "int", Default: 20, Description: "Maximum versions"}}, Examples: []string{"grafana dashboards versions --uid incident-overview --limit 5"}, OutputShape: `[{"version":1}]`, RelatedCommands: []string{"dashboards get", "dashboards render"}, TokenCost: "small"},
+				{Name: "render", Description: "Render a dashboard or panel to a PNG file", ReadOnly: true, Flags: []discoveryFlag{{Name: "--uid", Type: "string", Description: "Dashboard UID"}, {Name: "--slug", Type: "string", Description: "Dashboard slug"}, {Name: "--panel-id", Type: "int", Default: 0, Description: "Panel ID"}, {Name: "--width", Type: "int", Default: 1600, Description: "Output width"}, {Name: "--height", Type: "int", Default: 900, Description: "Output height"}, {Name: "--theme", Type: "string", Default: "light", Description: "Render theme"}, {Name: "--from", Type: "string", Default: "now-6h", Description: "Time range start"}, {Name: "--to", Type: "string", Default: "now", Description: "Time range end"}, {Name: "--tz", Type: "string", Default: "UTC", Description: "Time zone"}, {Name: "--out", Type: "path", Description: "Destination PNG path"}}, Examples: []string{"grafana dashboards render --uid incident-overview --panel-id 4 --out /tmp/panel.png"}, OutputShape: `{"path":"/tmp/panel.png","bytes":12345}`, RelatedCommands: []string{"dashboards get", "annotations list"}, TokenCost: "medium"},
+			},
+		},
+		{
+			Name:        "datasources",
+			Description: "Inspect configured datasources",
+			ReadOnly:    true,
+			Subcommands: []discoveryCommand{
+				{Name: "list", Description: "List datasources with optional filtering", ReadOnly: true, Flags: []discoveryFlag{{Name: "--type", Type: "string", Description: "Datasource type filter"}, {Name: "--name", Type: "string", Description: "Datasource name substring"}}, Examples: []string{"grafana datasources list --type loki"}, OutputShape: `[{"name":"loki","type":"loki"}]`, RelatedCommands: []string{"runtime logs query", "runtime metrics query"}, TokenCost: "small"},
+			},
+		},
+		{
+			Name:        "folders",
+			Description: "Inspect dashboard folders",
+			ReadOnly:    true,
+			Subcommands: []discoveryCommand{
+				{Name: "list", Description: "List folders", ReadOnly: true, Examples: []string{"grafana folders list"}, OutputShape: `[{"uid":"root"}]`, RelatedCommands: []string{"folders get", "dashboards list"}, TokenCost: "small"},
+				{Name: "get", Description: "Get one folder by UID", ReadOnly: true, Flags: []discoveryFlag{{Name: "--uid", Type: "string", Description: "Folder UID"}}, Examples: []string{"grafana folders get --uid ops"}, OutputShape: `{"uid":"ops"}`, RelatedCommands: []string{"folders list", "dashboards list"}, TokenCost: "small"},
+			},
+		},
+		{
+			Name:        "annotations",
+			Description: "Inspect dashboard and panel annotations",
+			ReadOnly:    true,
+			Subcommands: []discoveryCommand{
+				{Name: "list", Description: "List annotations for a dashboard or panel", ReadOnly: true, Flags: []discoveryFlag{{Name: "--dashboard-uid", Type: "string", Description: "Dashboard UID"}, {Name: "--panel-id", Type: "int", Default: 0, Description: "Panel ID"}, {Name: "--limit", Type: "int", Default: 100, Description: "Maximum annotations"}, {Name: "--from", Type: "string", Description: "Time range start"}, {Name: "--to", Type: "string", Description: "Time range end"}, {Name: "--tags", Type: "csv", Description: "Tag filters"}, {Name: "--type", Type: "string", Description: "Annotation type"}}, Examples: []string{"grafana annotations list --dashboard-uid ops --tags prod,error"}, OutputShape: `[{"id":1}]`, RelatedCommands: []string{"dashboards render", "folders get"}, TokenCost: "small"},
+			},
+		},
+		{
+			Name:        "alerting",
+			Description: "Inspect alerting configuration",
+			ReadOnly:    true,
+			Subcommands: []discoveryCommand{
+				{Name: "rules", Description: "Inspect alert rules", ReadOnly: true, Subcommands: []discoveryCommand{{Name: "list", Description: "List alert rules", ReadOnly: true, Examples: []string{"grafana alerting rules list"}, OutputShape: `[{"uid":"rule-1"}]`, RelatedCommands: []string{"alerting contact-points list", "alerting policies get"}, TokenCost: "small"}}},
+				{Name: "contact-points", Description: "Inspect alert contact points", ReadOnly: true, Subcommands: []discoveryCommand{{Name: "list", Description: "List contact points", ReadOnly: true, Examples: []string{"grafana alerting contact-points list"}, OutputShape: `[{"name":"pagerduty"}]`, RelatedCommands: []string{"alerting rules list", "alerting policies get"}, TokenCost: "small"}}},
+				{Name: "policies", Description: "Inspect alert routing policies", ReadOnly: true, Subcommands: []discoveryCommand{{Name: "get", Description: "Get the alert policy tree", ReadOnly: true, Examples: []string{"grafana alerting policies get"}, OutputShape: `{"receiver":"default"}`, RelatedCommands: []string{"alerting rules list", "alerting contact-points list"}, TokenCost: "small"}}},
+			},
+		},
+		{
+			Name:        "query-history",
+			Description: "Inspect saved Explore query history with bounded pagination metadata",
+			ReadOnly:    true,
+			Subcommands: []discoveryCommand{
+				{Name: "list", Description: "List query history entries with server-side search and paging", ReadOnly: true, Flags: []discoveryFlag{{Name: "--datasource-uid", Type: "csv", Description: "Datasource UID filter"}, {Name: "--search", Type: "string", Description: "Search text across queries and comments"}, {Name: "--starred", Type: "bool", Default: false, Description: "Only starred queries"}, {Name: "--sort", Type: "string", Default: "time-desc", Description: "time-desc or time-asc"}, {Name: "--page", Type: "int", Default: 1, Description: "Page number"}, {Name: "--limit", Type: "int", Default: 100, Description: "Page size"}, {Name: "--from", Type: "string", Description: "Time range start"}, {Name: "--to", Type: "string", Description: "Time range end"}}, Examples: []string{`grafana query-history list --search checkout --limit 20`, `grafana query-history list --datasource-uid loki-uid --starred --from 24h`}, OutputShape: `{"result":{"queryHistory":[...],"totalCount":42}}`, RelatedCommands: []string{"datasources list", "runtime logs query"}, TokenCost: "small"},
+			},
+		},
+		{
+			Name:        "slo",
+			Description: "Inspect SLO definitions from the Grafana SLO app",
+			ReadOnly:    true,
+			Subcommands: []discoveryCommand{
+				{Name: "list", Description: "List SLO definitions with local filtering and truncation metadata", ReadOnly: true, Flags: []discoveryFlag{{Name: "--query", Type: "string", Description: "Match by name or description"}, {Name: "--limit", Type: "int", Default: 100, Description: "Maximum SLOs to return"}}, Examples: []string{`grafana slo list`, `grafana slo list --query checkout --limit 20`}, OutputShape: `[{"name":"checkout-availability"}]`, RelatedCommands: []string{"incident analyze", "alerting rules list"}, TokenCost: "small"},
+			},
+		},
+		{
+			Name:        "irm",
+			Description: "Inspect Grafana IRM incidents with compact preview payloads",
+			ReadOnly:    true,
+			Subcommands: []discoveryCommand{
+				{Name: "incidents", Description: "Inspect incidents", ReadOnly: true, Subcommands: []discoveryCommand{{Name: "list", Description: "List incident previews from Grafana IRM", ReadOnly: true, Flags: []discoveryFlag{{Name: "--query", Type: "string", Description: "Incident search text"}, {Name: "--limit", Type: "int", Default: 20, Description: "Maximum incidents"}, {Name: "--order-field", Type: "string", Default: "createdAt", Description: "Incident sort field"}, {Name: "--order-direction", Type: "string", Default: "desc", Description: "asc or desc"}}, Examples: []string{`grafana irm incidents list --query checkout --limit 10`, `grafana irm incidents list --order-field updatedAt --order-direction asc`}, OutputShape: `{"results":[{"incident":{"title":"Checkout latency"}}]}`, RelatedCommands: []string{"incident analyze", "oncall schedules list"}, TokenCost: "small"}}},
+			},
+		},
+		{
+			Name:        "oncall",
+			Description: "Inspect Grafana OnCall schedules through the OnCall API",
+			ReadOnly:    true,
+			Subcommands: []discoveryCommand{
+				{Name: "schedules", Description: "Inspect OnCall schedules", ReadOnly: true, Subcommands: []discoveryCommand{{Name: "list", Description: "List OnCall schedules with compact filtering metadata", ReadOnly: true, Flags: []discoveryFlag{{Name: "--query", Type: "string", Description: "Schedule name or team filter"}, {Name: "--limit", Type: "int", Default: 50, Description: "Maximum schedules"}}, Examples: []string{`grafana oncall schedules list --query primary`, `grafana oncall schedules list --limit 20`}, OutputShape: `{"results":[{"name":"Primary OnCall"}]}`, RelatedCommands: []string{"auth doctor", "irm incidents list"}, TokenCost: "small"}}},
+			},
+		},
+		{
+			Name:        "assistant",
+			Description: "Interact with Grafana Assistant",
+			ReadOnly:    false,
+			Subcommands: []discoveryCommand{
+				{Name: "chat", Description: "Send a prompt to Grafana Assistant", ReadOnly: false, Flags: []discoveryFlag{{Name: "--prompt", Type: "string", Description: "Assistant prompt"}, {Name: "--chat-id", Type: "string", Description: "Existing chat ID"}}, Examples: []string{`grafana assistant chat --prompt "Investigate elevated error rate"`}, OutputShape: `{"chatId":"chat_123"}`, RelatedCommands: []string{"assistant status", "assistant skills"}, TokenCost: "medium"},
+				{Name: "status", Description: "Poll Assistant chat status", ReadOnly: true, Flags: []discoveryFlag{{Name: "--chat-id", Type: "string", Description: "Chat ID"}}, Examples: []string{"grafana assistant status --chat-id chat_123"}, OutputShape: `{"status":"completed"}`, RelatedCommands: []string{"assistant chat", "assistant skills"}, TokenCost: "small"},
+				{Name: "skills", Description: "List Assistant skills", ReadOnly: true, Examples: []string{"grafana assistant skills"}, OutputShape: `{"items":[...]}`, RelatedCommands: []string{"assistant chat", "incident analyze"}, TokenCost: "small"},
+			},
+		},
+		{
+			Name:        "runtime",
+			Description: "Query metrics, logs, and traces for incident investigation",
+			ReadOnly:    true,
+			Subcommands: []discoveryCommand{
+				{Name: "metrics", Description: "Query metrics", ReadOnly: true, Subcommands: []discoveryCommand{{Name: "query", Description: "Run a PromQL range query", ReadOnly: true, Flags: []discoveryFlag{{Name: "--expr", Type: "string", Description: "PromQL expression"}, {Name: "--start", Type: "string", Description: "Time range start"}, {Name: "--end", Type: "string", Description: "Time range end"}, {Name: "--step", Type: "string", Default: "30s", Description: "Query step"}}, Examples: []string{`grafana runtime metrics query --expr 'sum(rate(http_requests_total[5m]))' --start 1h`}, OutputShape: `{"data":{"result":[...]}}`, RelatedCommands: []string{"runtime logs query", "aggregate snapshot"}, TokenCost: "medium"}}},
+				{Name: "logs", Description: "Query logs", ReadOnly: true, Subcommands: []discoveryCommand{
+					{Name: "query", Description: "Run a LogQL range query", ReadOnly: true, Flags: []discoveryFlag{{Name: "--query", Type: "string", Description: "LogQL query"}, {Name: "--start", Type: "string", Description: "Time range start"}, {Name: "--end", Type: "string", Description: "Time range end"}, {Name: "--limit", Type: "int", Default: 200, Description: "Maximum log streams"}}, Examples: []string{`grafana runtime logs query --query '{app="checkout"} |= "error"' --start 30m`}, OutputShape: `{"data":{"result":[...]}}`, RelatedCommands: []string{"runtime logs aggregate", "incident analyze"}, TokenCost: "medium"},
+					{Name: "aggregate", Description: "Summarize a LogQL query into stream and label counts", ReadOnly: true, Flags: []discoveryFlag{{Name: "--query", Type: "string", Description: "LogQL query"}, {Name: "--start", Type: "string", Description: "Time range start"}, {Name: "--end", Type: "string", Description: "Time range end"}, {Name: "--limit", Type: "int", Default: 200, Description: "Maximum log streams to inspect"}}, Examples: []string{`grafana runtime logs aggregate --query '{app="checkout"} |= "error"' --start 30m`}, OutputShape: `{"streams":12,"entries":96,"label_keys":["app","level"]}`, RelatedCommands: []string{"runtime logs query", "incident analyze"}, TokenCost: "small"},
+				}},
+				{Name: "traces", Description: "Search traces", ReadOnly: true, Subcommands: []discoveryCommand{
+					{Name: "search", Description: "Run a TraceQL search", ReadOnly: true, Flags: []discoveryFlag{{Name: "--query", Type: "string", Description: "TraceQL query"}, {Name: "--start", Type: "string", Description: "Time range start"}, {Name: "--end", Type: "string", Description: "Time range end"}, {Name: "--limit", Type: "int", Default: 200, Description: "Maximum trace matches"}}, Examples: []string{`grafana runtime traces search --query '{ span.http.status_code >= 500 }' --start 30m`}, OutputShape: `{"traces":[...]}`, RelatedCommands: []string{"runtime traces aggregate", "incident analyze"}, TokenCost: "medium"},
+					{Name: "aggregate", Description: "Summarize a TraceQL search into services and root operations", ReadOnly: true, Flags: []discoveryFlag{{Name: "--query", Type: "string", Description: "TraceQL query"}, {Name: "--start", Type: "string", Description: "Time range start"}, {Name: "--end", Type: "string", Description: "Time range end"}, {Name: "--limit", Type: "int", Default: 200, Description: "Maximum trace matches to inspect"}}, Examples: []string{`grafana runtime traces aggregate --query '{ status = error }' --start 30m`}, OutputShape: `{"trace_matches":18,"services":["checkout"],"root_operations":["GET /checkout"]}`, RelatedCommands: []string{"runtime traces search", "incident analyze"}, TokenCost: "small"},
+				}},
+			},
+		},
+		{
+			Name:        "aggregate",
+			Description: "Fetch a compact multi-signal snapshot across metrics, logs, and traces",
+			ReadOnly:    true,
+			Subcommands: []discoveryCommand{
+				{Name: "snapshot", Description: "Query metrics, logs, and traces in one bounded call", ReadOnly: true, Flags: []discoveryFlag{{Name: "--metric-expr", Type: "string", Description: "PromQL expression"}, {Name: "--log-query", Type: "string", Description: "LogQL query"}, {Name: "--trace-query", Type: "string", Description: "TraceQL query"}, {Name: "--start", Type: "string", Description: "Time range start"}, {Name: "--end", Type: "string", Description: "Time range end"}, {Name: "--step", Type: "string", Default: "30s", Description: "Metrics step"}, {Name: "--limit", Type: "int", Default: 200, Description: "Maximum logs and traces"}}, Examples: []string{`grafana aggregate snapshot --metric-expr 'sum(rate(http_requests_total[5m]))' --log-query '{app="checkout"}' --trace-query '{ resource.service.name = "checkout" }'`}, OutputShape: `{"metrics":{...},"logs":{...},"traces":{...}}`, RelatedCommands: []string{"incident analyze", "runtime metrics query"}, TokenCost: "medium"},
+			},
+		},
+		{
+			Name:        "incident",
+			Description: "Run a summary-first incident investigation workflow",
+			ReadOnly:    true,
+			Subcommands: []discoveryCommand{
+				{Name: "analyze", Description: "Generate a playbook-driven incident summary", ReadOnly: true, Flags: []discoveryFlag{{Name: "--goal", Type: "string", Description: "Incident goal"}, {Name: "--metric-expr", Type: "string", Description: "Override metric expression"}, {Name: "--log-query", Type: "string", Description: "Override log query"}, {Name: "--trace-query", Type: "string", Description: "Override trace query"}, {Name: "--start", Type: "string", Description: "Time range start"}, {Name: "--end", Type: "string", Description: "Time range end"}, {Name: "--step", Type: "string", Description: "Metrics step"}, {Name: "--limit", Type: "int", Description: "Maximum logs and traces"}, {Name: "--include-raw", Type: "bool", Default: false, Description: "Include the raw snapshot payload"}}, Examples: []string{`grafana incident analyze --goal "Investigate checkout latency spike"`}, OutputShape: `{"goal":"...","summary":{"metrics_series":1}}`, RelatedCommands: []string{"aggregate snapshot", "assistant chat"}, TokenCost: "medium"},
+			},
+		},
+		{
+			Name:        "agent",
+			Description: "Run compact planning and execution workflows for agents",
+			ReadOnly:    true,
+			Subcommands: []discoveryCommand{
+				{Name: "plan", Description: "Return the investigation plan without executing it", ReadOnly: true, Flags: []discoveryFlag{{Name: "--goal", Type: "string", Description: "Automation goal"}, {Name: "--include-raw", Type: "bool", Default: false, Description: "Include raw payloads when running"}}, Examples: []string{`grafana agent plan --goal "Investigate elevated error rate"`}, OutputShape: `{"goal":"...","playbook":[...]}`, RelatedCommands: []string{"agent run", "incident analyze"}, TokenCost: "small"},
+				{Name: "run", Description: "Execute the investigation plan against Grafana", ReadOnly: true, Flags: []discoveryFlag{{Name: "--goal", Type: "string", Description: "Automation goal"}, {Name: "--include-raw", Type: "bool", Default: false, Description: "Include raw payloads"}}, Examples: []string{`grafana agent run --goal "Investigate elevated error rate"`}, OutputShape: `{"plan":{...},"summary":{...}}`, RelatedCommands: []string{"agent plan", "incident analyze"}, TokenCost: "medium"},
+			},
+		},
+	}
+}
+
+func discoveryGlobalFlags() []discoveryFlag {
+	return []discoveryFlag{
+		{Name: "--output", Type: "string", Default: "json", Description: "Output format: json, pretty, table"},
+		{Name: "--fields", Type: "csv", Description: "Project only selected fields from the JSON payload"},
+		{Name: "--json", Type: "csv", Description: "Alias for --fields with JSON output"},
+		{Name: "--jq", Type: "string", Description: "Apply a jq expression to the payload"},
+		{Name: "--template", Type: "string", Description: "Render a Go template against the payload"},
+		{Name: "--agent", Type: "bool", Default: false, Description: "Wrap results in an agent envelope with metadata"},
+		{Name: "--read-only", Type: "bool", Default: false, Description: "Block commands that mutate local or remote state"},
+		{Name: "--yes", Type: "bool", Default: false, Description: "Confirm destructive commands without an interactive prompt"},
+	}
+}
+
+func discoveryAuthDocs() map[string]any {
+	return map[string]any{
+		"login":         `grafana auth login --token "$GRAFANA_TOKEN" --stack "<stack-slug>"`,
+		"diagnostics":   "grafana auth doctor",
+		"token_storage": "Token is stored via the OS keyring when available, with file fallback",
+		"expanded_help": "grafana schema --full runtime",
+	}
+}
+
+func discoveryBestPractices(path []string) []string {
+	practices := []string{
+		"Use subtree help before reading external docs: grafana <domain> --help",
+		"Prefer summary-first commands for investigations before fetching raw payloads",
+		"Use --json, --jq, or --template to keep responses narrow in agent loops",
+		"Keep default time windows small unless the investigation requires a wider range",
+	}
+	if hasPathPrefix(path, "runtime") || hasPathPrefix(path, "incident") || hasPathPrefix(path, "aggregate") || hasPathPrefix(path, "query-history") {
+		practices = append(practices, "Start with a 30m or 1h window, then widen only when the signal is too sparse")
+	}
+	return practices
+}
+
+func discoveryAntiPatterns(path []string) []string {
+	antiPatterns := []string{
+		"Do not fetch broad raw payloads first when a summary or filtered query would do",
+		"Do not widen time ranges and limits at the same time unless the first query was clearly too narrow",
+		"Do not use raw api calls when a dedicated command already exposes a stable contract",
+	}
+	if hasPathPrefix(path, "runtime") || hasPathPrefix(path, "incident") || hasPathPrefix(path, "aggregate") {
+		antiPatterns = append(antiPatterns, "Do not omit the query goal and then expect the CLI to infer a useful incident scope")
+	}
+	return antiPatterns
+}
+
+func discoveryTimeFormatsDoc(path []string) discoveryTimeFormats {
+	if !(hasPathPrefix(path, "runtime") || hasPathPrefix(path, "aggregate") || hasPathPrefix(path, "incident") || hasPathPrefix(path, "query-history") || len(path) == 0) {
+		return discoveryTimeFormats{}
+	}
+	return discoveryTimeFormats{
+		Relative: []string{"5m", "30m", "1h", "24h", "7d", "1w", "now-30m", "now"},
+		Absolute: []string{"RFC3339 timestamps such as 2026-03-06T14:04:00Z", "Unix timestamps are passed through unchanged"},
+		Examples: []string{"--start 30m --end now", "--start now-2h --end now", "--start 2026-03-06T13:00:00Z --end 2026-03-06T14:00:00Z"},
+	}
+}
+
+func discoveryQuerySyntax(path []string) map[string]string {
+	all := map[string]string{
+		"metrics": `PromQL expressions such as sum(rate(http_requests_total[5m])) by (service)`,
+		"logs":    `LogQL expressions such as {app="checkout"} |= "error"`,
+		"traces":  `TraceQL expressions such as { resource.service.name = "checkout" && span.http.status_code >= 500 }`,
+	}
+	switch {
+	case len(path) == 0:
+		return all
+	case hasPathPrefix(path, "runtime", "metrics"):
+		return map[string]string{"metrics": all["metrics"]}
+	case hasPathPrefix(path, "runtime", "logs"):
+		return map[string]string{"logs": all["logs"]}
+	case hasPathPrefix(path, "runtime", "traces"):
+		return map[string]string{"traces": all["traces"]}
+	case hasPathPrefix(path, "runtime"), hasPathPrefix(path, "aggregate"), hasPathPrefix(path, "incident"):
+		return all
+	default:
+		return nil
+	}
+}
+
+func discoveryWorkflows(path []string) []discoveryWorkflow {
+	workflows := []discoveryWorkflow{
+		{
+			Name:      "Inspect Runtime Signals",
+			TokenCost: "medium",
+			Steps: []string{
+				`grafana runtime metrics query --expr 'sum(rate(http_requests_total[5m])) by (service)' --start 30m`,
+				`grafana runtime logs query --query '{app="checkout"} |= "error"' --start 30m --limit 20`,
+				`grafana runtime traces search --query '{ resource.service.name = "checkout" }' --start 30m --limit 20`,
+			},
+		},
+		{
+			Name:      "Summarize An Incident",
+			TokenCost: "small",
+			Steps: []string{
+				`grafana query-history list --search checkout --from 24h`,
+				`grafana slo list --query checkout`,
+				`grafana irm incidents list --query checkout --limit 10`,
+				`grafana oncall schedules list --query checkout`,
+				`grafana incident analyze --goal "Investigate checkout latency spike"`,
+				`grafana --json summary incident analyze --goal "Investigate checkout latency spike"`,
+			},
+		},
+	}
+	if len(path) == 0 || hasPathPrefix(path, "runtime") || hasPathPrefix(path, "incident") || hasPathPrefix(path, "aggregate") || hasPathPrefix(path, "query-history") || hasPathPrefix(path, "slo") {
+		return workflows
+	}
+	return nil
+}
+
+func hasPathPrefix(path []string, prefix ...string) bool {
+	if len(prefix) == 0 || len(path) < len(prefix) {
+		return false
+	}
+	for i := range prefix {
+		if path[i] != prefix[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func compactCommandPayload(command discoveryCommand, prefix []string) map[string]any {
+	path := append(append([]string{}, prefix...), command.Name)
+	payload := map[string]any{
+		"name":        command.Name,
+		"full_path":   strings.Join(path, " "),
+		"description": command.Description,
+		"read_only":   command.ReadOnly,
+	}
+	if command.TokenCost != "" {
+		payload["token_cost"] = command.TokenCost
+	}
+	if len(command.Flags) > 0 {
+		payload["flags"] = command.Flags
+	}
+	if len(command.Subcommands) > 0 {
+		children := make([]map[string]any, 0, len(command.Subcommands))
+		for _, child := range command.Subcommands {
+			children = append(children, compactCommandPayload(child, path))
+		}
+		payload["subcommands"] = children
+	}
+	return payload
+}
+
+func fullCommandPayload(command discoveryCommand, prefix []string) map[string]any {
+	payload := compactCommandPayload(command, prefix)
+	if command.OutputShape != "" {
+		payload["output_shape"] = command.OutputShape
+	}
+	if len(command.Examples) > 0 {
+		payload["examples"] = command.Examples
+	}
+	if len(command.RelatedCommands) > 0 {
+		payload["related_commands"] = command.RelatedCommands
+	}
+	return payload
+}
+
+func buildDiscoveryPayload(path []string, compact bool) (map[string]any, error) {
+	commands := discoveryCatalog()
+	if len(path) > 0 {
+		command, ok := findDiscoveryCommand(commands, path)
+		if !ok {
+			return nil, errors.New("unknown schema path")
+		}
+		commands = []discoveryCommand{command}
+	}
+
+	commandPayloads := make([]map[string]any, 0, len(commands))
+	for _, command := range commands {
+		if compact {
+			commandPayloads = append(commandPayloads, compactCommandPayload(command, nil))
+			continue
+		}
+		commandPayloads = append(commandPayloads, fullCommandPayload(command, nil))
+	}
+
+	payload := map[string]any{
+		"version":      cliVersion,
+		"description":  "Agent-first CLI for Grafana and Grafana Cloud with deterministic, token-aware command contracts.",
+		"auth":         discoveryAuthDocs(),
+		"global_flags": discoveryGlobalFlags(),
+		"commands":     commandPayloads,
+	}
+	if len(path) > 0 {
+		payload["scope"] = strings.Join(path, " ")
+	}
+	if syntax := discoveryQuerySyntax(path); len(syntax) > 0 && (!compact || len(path) > 0) {
+		payload["query_syntax"] = syntax
+	}
+	if timeFormats := discoveryTimeFormatsDoc(path); (len(timeFormats.Relative) > 0 || len(timeFormats.Absolute) > 0 || len(timeFormats.Examples) > 0) && (!compact || len(path) > 0) {
+		payload["time_formats"] = timeFormats
+	}
+	if !compact {
+		payload["best_practices"] = discoveryBestPractices(path)
+		payload["anti_patterns"] = discoveryAntiPatterns(path)
+		if workflows := discoveryWorkflows(path); len(workflows) > 0 {
+			payload["workflows"] = workflows
+		}
+	}
+	return payload, nil
+}
+
+func findDiscoveryCommand(commands []discoveryCommand, path []string) (discoveryCommand, bool) {
+	if len(path) == 0 {
+		return discoveryCommand{}, false
+	}
+	for _, command := range commands {
+		if command.Name != path[0] {
+			continue
+		}
+		if len(path) == 1 {
+			return command, true
+		}
+		return findDiscoveryCommand(command.Subcommands, path[1:])
+	}
+	return discoveryCommand{}, false
+}
+
+func discoveryPathFromArgs(args []string) []string {
+	if len(args) == 0 {
+		return nil
+	}
+	path := make([]string, 0, len(args))
+	commands := discoveryCatalog()
+	for _, arg := range args {
+		trimmed := strings.TrimSpace(arg)
+		if trimmed == "" || isHelpArg(trimmed) || strings.HasPrefix(trimmed, "-") {
+			break
+		}
+		command, ok := findDiscoveryCommand(commands, []string{trimmed})
+		if !ok {
+			break
+		}
+		path = append(path, trimmed)
+		commands = command.Subcommands
+	}
+	return path
+}
+
+func requestedHelpPath(args []string) ([]string, bool) {
+	for _, arg := range args {
+		if isHelpArg(arg) {
+			return discoveryPathFromArgs(args), true
+		}
+	}
+	return nil, false
+}

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -1,0 +1,181 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+type responseMetadata struct {
+	Count      *int     `json:"count,omitempty"`
+	Truncated  bool     `json:"truncated,omitempty"`
+	Command    string   `json:"command,omitempty"`
+	NextAction string   `json:"next_action,omitempty"`
+	Warnings   []string `json:"warnings,omitempty"`
+}
+
+type responseEnvelope struct {
+	Status   string            `json:"status"`
+	Data     any               `json:"data"`
+	Metadata *responseMetadata `json:"metadata,omitempty"`
+}
+
+var collectionKeys = []string{"items", "data", "results", "result", "traces", "queryHistory", "slos"}
+
+func withCommandMetadata(meta *responseMetadata, command string) *responseMetadata {
+	if meta == nil {
+		meta = &responseMetadata{}
+	}
+	meta.Command = command
+	return meta
+}
+
+func collectionMetadata(command string, payload any, limit int, nextAction string) *responseMetadata {
+	count, ok := inferMetadataCount(payload)
+	if !ok && command == "" && nextAction == "" && limit <= 0 {
+		return nil
+	}
+	meta := &responseMetadata{Command: command}
+	if ok {
+		meta.Count = &count
+	}
+	if limit > 0 && ok && count >= limit {
+		meta.Truncated = true
+		if strings.TrimSpace(nextAction) != "" {
+			meta.NextAction = nextAction
+		}
+	}
+	return meta
+}
+
+func inferMetadataCount(payload any) (int, bool) {
+	switch value := payload.(type) {
+	case []any:
+		return len(value), true
+	case map[string]any:
+		for _, key := range collectionKeys {
+			candidate, ok := value[key]
+			if !ok {
+				continue
+			}
+			switch typed := candidate.(type) {
+			case []any:
+				return len(typed), true
+			case map[string]any:
+				if nested, ok := inferMetadataCount(typed); ok {
+					return nested, true
+				}
+			}
+		}
+	}
+	return 0, false
+}
+
+func renderTable(out io.Writer, payload any) error {
+	rows := rowsForTable(payload)
+	if len(rows) == 0 {
+		_, err := fmt.Fprintln(out, "No rows")
+		return err
+	}
+	headers := tableHeaders(rows)
+	if _, err := fmt.Fprintln(out, strings.Join(headers, "\t")); err != nil {
+		return err
+	}
+	for _, row := range rows {
+		values := make([]string, 0, len(headers))
+		for _, header := range headers {
+			values = append(values, tableCell(row[header]))
+		}
+		if _, err := fmt.Fprintln(out, strings.Join(values, "\t")); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func rowsForTable(payload any) []map[string]any {
+	switch value := payload.(type) {
+	case []any:
+		rows := make([]map[string]any, 0, len(value))
+		for _, item := range value {
+			if row, ok := item.(map[string]any); ok {
+				rows = append(rows, flattenTableRow(row, ""))
+			}
+		}
+		return rows
+	case map[string]any:
+		if count, ok := inferMetadataCount(value); ok && count > 0 {
+			for _, key := range collectionKeys {
+				candidate, ok := value[key]
+				if !ok {
+					continue
+				}
+				if rows := rowsForTable(candidate); len(rows) > 0 {
+					return rows
+				}
+			}
+		}
+		return []map[string]any{flattenTableRow(value, "")}
+	default:
+		return nil
+	}
+}
+
+func flattenTableRow(row map[string]any, prefix string) map[string]any {
+	flat := map[string]any{}
+	for key, value := range row {
+		name := key
+		if prefix != "" {
+			name = prefix + "." + key
+		}
+		if nested, ok := value.(map[string]any); ok {
+			for childKey, childValue := range flattenTableRow(nested, name) {
+				flat[childKey] = childValue
+			}
+			continue
+		}
+		flat[name] = value
+	}
+	return flat
+}
+
+func tableHeaders(rows []map[string]any) []string {
+	set := map[string]struct{}{}
+	for _, row := range rows {
+		for key := range row {
+			set[key] = struct{}{}
+		}
+	}
+	headers := make([]string, 0, len(set))
+	for key := range set {
+		headers = append(headers, key)
+	}
+	sort.Strings(headers)
+	return headers
+}
+
+func tableCell(value any) string {
+	switch typed := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return typed
+	case bool:
+		if typed {
+			return "true"
+		}
+		return "false"
+	case float64, float32, int, int64, int32, uint, uint64:
+		return fmt.Sprint(typed)
+	case []any:
+		return fmt.Sprintf("[%d items]", len(typed))
+	default:
+		data, err := json.Marshal(typed)
+		if err != nil {
+			return fmt.Sprint(typed)
+		}
+		return string(data)
+	}
+}

--- a/internal/cli/time.go
+++ b/internal/cli/time.go
@@ -1,0 +1,78 @@
+package cli
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var relativeTimePattern = regexp.MustCompile(`^(\d+)(s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days|w|week|weeks)$`)
+
+func normalizeTimeRange(now time.Time, start, end string, defaultWindow time.Duration) (string, string) {
+	endValue := normalizeTimeValue(now, end)
+	startValue := normalizeTimeValue(now, start)
+
+	base := now.UTC()
+	if parsedEnd, err := time.Parse(time.RFC3339, endValue); err == nil {
+		base = parsedEnd
+	}
+
+	if endValue == "" && defaultWindow > 0 {
+		endValue = now.UTC().Format(time.RFC3339)
+	}
+	if startValue == "" && defaultWindow > 0 {
+		startValue = base.Add(-defaultWindow).UTC().Format(time.RFC3339)
+	}
+	return startValue, endValue
+}
+
+func normalizeTimeValue(now time.Time, value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return ""
+	}
+	if strings.EqualFold(trimmed, "now") {
+		return now.UTC().Format(time.RFC3339)
+	}
+	if parsed, err := time.Parse(time.RFC3339, trimmed); err == nil {
+		return parsed.UTC().Format(time.RFC3339)
+	}
+	if strings.HasPrefix(strings.ToLower(trimmed), "now-") {
+		if duration, ok := parseRelativeDuration(strings.TrimPrefix(strings.ToLower(trimmed), "now-")); ok {
+			return now.Add(-duration).UTC().Format(time.RFC3339)
+		}
+	}
+	if duration, ok := parseRelativeDuration(trimmed); ok {
+		return now.Add(-duration).UTC().Format(time.RFC3339)
+	}
+	return trimmed
+}
+
+func parseRelativeDuration(value string) (time.Duration, bool) {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	normalized = strings.TrimPrefix(normalized, "-")
+	normalized = strings.ReplaceAll(normalized, " ", "")
+	matches := relativeTimePattern.FindStringSubmatch(normalized)
+	if len(matches) != 3 {
+		return 0, false
+	}
+	amount, err := strconv.Atoi(matches[1])
+	if err != nil || amount < 0 {
+		return 0, false
+	}
+	multiplier := time.Second
+	switch matches[2] {
+	case "s", "sec", "secs", "second", "seconds":
+		multiplier = time.Second
+	case "m", "min", "mins", "minute", "minutes":
+		multiplier = time.Minute
+	case "h", "hr", "hrs", "hour", "hours":
+		multiplier = time.Hour
+	case "d", "day", "days":
+		multiplier = 24 * time.Hour
+	case "w", "week", "weeks":
+		multiplier = 7 * 24 * time.Hour
+	}
+	return time.Duration(amount) * multiplier, true
+}

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -21,6 +21,7 @@ type Config struct {
 	PrometheusURL string `json:"prometheus_url"`
 	LogsURL       string `json:"logs_url"`
 	TracesURL     string `json:"traces_url"`
+	OnCallURL     string `json:"oncall_url"`
 	Token         string `json:"token,omitempty"`
 	TokenBackend  string `json:"-"`
 	OrgID         int64  `json:"org_id"`


### PR DESCRIPTION
## Summary

- make discovery compact by default and add explicit `schema --full` expansion with workflow token-cost metadata
- simplify auth with stack-based endpoint inference, richer `auth status`/`auth doctor`, and persisted `oncall_url`
- add destructive confirmation via `--yes`, plus new `irm incidents list` and `oncall schedules list` investigation commands
- update README and the discovery-first plan to reflect the shipped contract

## Agent Impact

- Token usage impact: compact schema stays the default help surface; expanded workflows and guidance are opt-in through `schema --full`; new list commands return bounded metadata for count/truncation
- Output contract changes: `auth status` and `auth login` now include capability/missing-endpoint metadata; discovery schema now distinguishes compact vs full mode; agent envelopes cover IRM and OnCall commands
- Command/API behavior changes: `auth login` supports `--stack`, `--cloud-token`, and `--oncall-url`; `auth logout`, `dashboards delete`, and raw API write methods now require `--yes`; new commands are `irm incidents list` and `oncall schedules list`

## Quality Checklist

- [x] `golangci-lint` passes locally
- [x] `go test ./...` passes locally
- [x] Coverage is `100.0%` (`go tool cover -func=coverage.out | tail -n 1`)
- [x] Tests added/updated for behavior changes
- [x] README/docs updated when command contracts changed
