### PR TITLE
feat(cli): add cloud access, synthetics, and investigation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Agent-first CLI for Grafana and Grafana Cloud. Built for engineers working with 
 - **Discoverable** - `grafana schema --compact` returns a machine-readable command catalog in one bounded call
 - **Structured** - compact JSON by default with `--json`, `--jq`, and `--template` for output shaping
 - **Secure** - OS keyring token storage, `--read-only` guardrail, `--yes` for explicit destructive confirms
-- **Broad** - dashboards, alerting, logs, metrics, traces, assistant, incidents, OnCall, and SLOs
+- **Broad** - dashboards, alerting, logs, metrics, traces, assistant, incidents, OnCall, SLOs, service accounts, access policies, and synthetics
 - **Token-aware** - every command is designed to minimize token usage in agent loops
 
 ## Try It
@@ -21,11 +21,23 @@ grafana auth login --token "$GRAFANA_TOKEN" --stack my-stack
 # Check what's configured
 grafana auth doctor
 
+# Inspect activation surfaces
+grafana service-accounts list
+grafana cloud access-policies list --region us
+
+# Inspect Synthetic Monitoring checks
+grafana synthetics checks list \
+  --backend-url "$GRAFANA_SYNTHETICS_BACKEND_URL" \
+  --token "$GRAFANA_SYNTHETICS_TOKEN"
+
 # Search dashboards
 grafana dashboards list --query latency --tag prod
 
 # Query logs from the last 30 minutes
 grafana runtime logs query --query '{app="checkout"} |= "error"' --start 30m
+
+# Start an assistant-led investigation
+grafana assistant investigate --goal "Investigate checkout latency spike"
 
 # Investigate an incident
 grafana incident analyze --goal "Investigate checkout latency spike"
@@ -33,7 +45,6 @@ grafana incident analyze --goal "Investigate checkout latency spike"
 # Shape output for your agent
 grafana --json summary incident analyze --goal "Latency spike"
 grafana --jq '.summary' incident analyze --goal "Latency spike"
-
 # Wrap in a deterministic envelope for downstream parsing
 grafana --agent incident analyze --goal "Latency spike"
 ```
@@ -145,8 +156,23 @@ All runtime commands support relative time inputs: `30m`, `1h`, `now-2h`, `2026-
 | Command | Description |
 |---------|-------------|
 | `assistant chat --prompt ...` | Send a prompt to Grafana Assistant |
+| `assistant investigate --goal ...` | Start an assistant-led investigation for an operational goal |
 | `assistant status --chat-id ...` | Poll assistant chat status |
 | `assistant skills` | List available assistant skills |
+
+</details>
+
+<details>
+<summary><strong>Access & Synthetics</strong></summary>
+
+| Command | Description |
+|---------|-------------|
+| `service-accounts list` | Search Grafana service accounts with paging metadata |
+| `service-accounts get --id ...` | Fetch one service account by ID |
+| `cloud access-policies list --region ...` | List Grafana Cloud access policies for a region |
+| `cloud access-policies get --id ... --region ...` | Fetch one Grafana Cloud access policy |
+| `synthetics checks list --backend-url ... --token ...` | List Synthetic Monitoring checks |
+| `synthetics checks get --backend-url ... --token ... --id ...` | Fetch one Synthetic Monitoring check |
 
 </details>
 
@@ -209,7 +235,7 @@ The CLI treats discovery as a first-class interface - agents can understand the 
 grafana --help                        # Compact root schema
 grafana runtime --help                # Compact runtime subtree
 grafana runtime metrics query --help  # Expanded scoped help for one leaf command
-grafana schema                        # Bounded machine-readable contract (compact by default)
+grafana schema                       # Bounded machine-readable contract (compact by default)
 grafana schema --full runtime metrics # Richer contract with examples, workflows, and query syntax
 ```
 
@@ -235,7 +261,7 @@ Releases are automatic on every merge to `main`. Versioning follows [Conventiona
 
 ## Roadmap
 
-- Broader Grafana Cloud product coverage (synthetic monitoring, k6, profiles, frontend observability)
+- Broader Grafana Cloud product coverage (k6, profiles, frontend observability, deeper synthetic monitoring write flows)
 - Richer agent execution plans and remediation actions
 - Graph RAG for past incidents to reuse historical context during triage
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -27,6 +27,8 @@ import (
 type APIClient interface {
 	Raw(ctx context.Context, method, path string, body any) (any, error)
 	CloudStacks(ctx context.Context) (any, error)
+	CloudAccessPolicies(ctx context.Context, req grafana.CloudAccessPolicyListRequest) (any, error)
+	CloudAccessPolicy(ctx context.Context, id, region string) (any, error)
 	SearchDashboards(ctx context.Context, query, tag string, limit int) (any, error)
 	GetDashboard(ctx context.Context, uid string) (any, error)
 	CreateDashboard(ctx context.Context, dashboard map[string]any, folderID int64, overwrite bool) (any, error)
@@ -36,6 +38,8 @@ type APIClient interface {
 	ListDatasources(ctx context.Context) (any, error)
 	ListFolders(ctx context.Context) (any, error)
 	GetFolder(ctx context.Context, uid string) (any, error)
+	ServiceAccounts(ctx context.Context, req grafana.ServiceAccountListRequest) (any, error)
+	ServiceAccount(ctx context.Context, id int64) (any, error)
 	ListAnnotations(ctx context.Context, req grafana.AnnotationListRequest) (any, error)
 	AlertingRules(ctx context.Context) (any, error)
 	AlertingContactPoints(ctx context.Context) (any, error)
@@ -43,6 +47,8 @@ type APIClient interface {
 	AssistantChat(ctx context.Context, prompt, chatID string) (any, error)
 	AssistantChatStatus(ctx context.Context, chatID string) (any, error)
 	AssistantSkills(ctx context.Context) (any, error)
+	SyntheticChecks(ctx context.Context, req grafana.SyntheticCheckListRequest) (any, error)
+	SyntheticCheck(ctx context.Context, req grafana.SyntheticCheckGetRequest) (any, error)
 	MetricsRange(ctx context.Context, expr, start, end, step string) (any, error)
 	LogsRange(ctx context.Context, query, start, end string, limit int) (any, error)
 	TracesSearch(ctx context.Context, query, start, end string, limit int) (any, error)
@@ -130,6 +136,8 @@ func (a *App) Run(ctx context.Context, args []string) int {
 		runErr = a.runAPI(ctx, opts, rest[1:])
 	case "cloud":
 		runErr = a.runCloud(ctx, opts, rest[1:])
+	case "service-accounts":
+		runErr = a.runServiceAccounts(ctx, opts, rest[1:])
 	case "dashboards":
 		runErr = a.runDashboards(ctx, opts, rest[1:])
 	case "datasources":
@@ -146,6 +154,8 @@ func (a *App) Run(ctx context.Context, args []string) int {
 		runErr = a.runSLO(ctx, opts, rest[1:])
 	case "assistant":
 		runErr = a.runAssistant(ctx, opts, rest[1:])
+	case "synthetics":
+		runErr = a.runSynthetics(ctx, opts, rest[1:])
 	case "runtime":
 		runErr = a.runRuntime(ctx, opts, rest[1:])
 	case "aggregate":
@@ -428,21 +438,25 @@ func (a *App) runCloud(ctx context.Context, opts globalOptions, args []string) e
 	if len(args) == 0 || isHelpArg(args[0]) {
 		return a.emitHelp(opts, []string{"cloud"}, true)
 	}
-	if args[0] != "stacks" {
+	switch args[0] {
+	case "stacks":
+		if len(args) < 2 || args[1] != "list" {
+			return errors.New("usage: cloud stacks list")
+		}
+		cfg, err := a.requireAuthConfig()
+		if err != nil {
+			return err
+		}
+		result, err := a.NewClient(cfg).CloudStacks(ctx)
+		if err != nil {
+			return err
+		}
+		return a.emitWithMetadata(opts, result, collectionMetadata("cloud stacks list", result, 0, ""))
+	case "access-policies":
+		return a.runCloudAccessPolicies(ctx, opts, args[1:])
+	default:
 		return fmt.Errorf("unknown cloud command: %s", args[0])
 	}
-	if len(args) < 2 || args[1] != "list" {
-		return errors.New("usage: cloud stacks list")
-	}
-	cfg, err := a.requireAuthConfig()
-	if err != nil {
-		return err
-	}
-	result, err := a.NewClient(cfg).CloudStacks(ctx)
-	if err != nil {
-		return err
-	}
-	return a.emitWithMetadata(opts, result, collectionMetadata("cloud stacks list", result, 0, ""))
 }
 
 func (a *App) runDashboards(ctx context.Context, opts globalOptions, args []string) error {
@@ -919,6 +933,30 @@ func (a *App) runAssistant(ctx context.Context, opts globalOptions, args []strin
 			return err
 		}
 		return a.emitWithMetadata(opts, result, collectionMetadata("assistant skills", result, 0, ""))
+	case "investigate":
+		fs := flag.NewFlagSet("assistant investigate", flag.ContinueOnError)
+		fs.SetOutput(io.Discard)
+		goal := fs.String("goal", "", "investigation goal")
+		chatID := fs.String("chat-id", "", "existing chat ID to continue")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if strings.TrimSpace(*goal) == "" {
+			return errors.New("--goal is required")
+		}
+		result, err := client.AssistantChat(ctx, investigationPrompt(*goal), *chatID)
+		if err != nil {
+			return err
+		}
+		payload := map[string]any{
+			"goal": strings.TrimSpace(*goal),
+			"chat": result,
+		}
+		meta := &responseMetadata{Command: "assistant investigate"}
+		if chatIdentifier := firstNonEmptyString(mapValue(payload, "chat"), "chatId", "chatID", "id"); chatIdentifier != "" {
+			meta.NextAction = "Use `grafana assistant status --chat-id " + chatIdentifier + "` to poll the investigation"
+		}
+		return a.emitWithMetadata(opts, payload, meta)
 	default:
 		return fmt.Errorf("unknown assistant command: %s", args[0])
 	}
@@ -1604,7 +1642,12 @@ func payloadHasNextPage(payload any) bool {
 	if !ok {
 		return false
 	}
-	return strings.TrimSpace(firstNonEmptyString(root, "next", "nextPage")) != ""
+	if strings.TrimSpace(firstNonEmptyString(root, "next", "nextPage")) != "" {
+		return true
+	}
+	metadata := mapValue(root, "metadata")
+	pagination := mapValue(metadata, "pagination")
+	return strings.TrimSpace(firstNonEmptyString(pagination, "next", "nextPage")) != ""
 }
 
 func enforceConfirmation(args []string) error {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -197,6 +197,13 @@ type fakeClient struct {
 	rawCalls            []string
 	cloudResult         any
 	cloudErr            error
+	cloudAccessResult   any
+	cloudAccessErr      error
+	cloudAccessReq      grafana.CloudAccessPolicyListRequest
+	cloudAccessOne      any
+	cloudAccessOneErr   error
+	cloudAccessID       string
+	cloudAccessRegion   string
 	searchDashResult    any
 	searchDashErr       error
 	getDashResult       any
@@ -216,6 +223,12 @@ type fakeClient struct {
 	listFoldersErr      error
 	getFolderResult     any
 	getFolderErr        error
+	serviceAccountsResp any
+	serviceAccountsErr  error
+	serviceAccountsReq  grafana.ServiceAccountListRequest
+	serviceAccountResp  any
+	serviceAccountErr   error
+	serviceAccountID    int64
 	annotationsResult   any
 	annotationsErr      error
 	annotationsReq      grafana.AnnotationListRequest
@@ -252,6 +265,12 @@ type fakeClient struct {
 	tracesStart         string
 	tracesEnd           string
 	tracesLimit         int
+	syntheticChecksResp any
+	syntheticChecksErr  error
+	syntheticChecksReq  grafana.SyntheticCheckListRequest
+	syntheticCheckResp  any
+	syntheticCheckErr   error
+	syntheticCheckReq   grafana.SyntheticCheckGetRequest
 	aggregateResult     grafana.AggregateSnapshot
 	aggregateErr        error
 	aggregateReq        grafana.AggregateRequest
@@ -276,6 +295,17 @@ func (f *fakeClient) Raw(_ context.Context, method, path string, body any) (any,
 
 func (f *fakeClient) CloudStacks(_ context.Context) (any, error) {
 	return f.cloudResult, f.cloudErr
+}
+
+func (f *fakeClient) CloudAccessPolicies(_ context.Context, req grafana.CloudAccessPolicyListRequest) (any, error) {
+	f.cloudAccessReq = req
+	return f.cloudAccessResult, f.cloudAccessErr
+}
+
+func (f *fakeClient) CloudAccessPolicy(_ context.Context, id, region string) (any, error) {
+	f.cloudAccessID = id
+	f.cloudAccessRegion = region
+	return f.cloudAccessOne, f.cloudAccessOneErr
 }
 
 func (f *fakeClient) SearchDashboards(_ context.Context, _, _ string, _ int) (any, error) {
@@ -318,6 +348,16 @@ func (f *fakeClient) GetFolder(_ context.Context, _ string) (any, error) {
 	return f.getFolderResult, f.getFolderErr
 }
 
+func (f *fakeClient) ServiceAccounts(_ context.Context, req grafana.ServiceAccountListRequest) (any, error) {
+	f.serviceAccountsReq = req
+	return f.serviceAccountsResp, f.serviceAccountsErr
+}
+
+func (f *fakeClient) ServiceAccount(_ context.Context, id int64) (any, error) {
+	f.serviceAccountID = id
+	return f.serviceAccountResp, f.serviceAccountErr
+}
+
 func (f *fakeClient) ListAnnotations(_ context.Context, req grafana.AnnotationListRequest) (any, error) {
 	f.annotationsReq = req
 	return f.annotationsResult, f.annotationsErr
@@ -348,6 +388,16 @@ func (f *fakeClient) AssistantChatStatus(_ context.Context, chatID string) (any,
 
 func (f *fakeClient) AssistantSkills(_ context.Context) (any, error) {
 	return f.assistantSkillsResp, f.assistantSkillsErr
+}
+
+func (f *fakeClient) SyntheticChecks(_ context.Context, req grafana.SyntheticCheckListRequest) (any, error) {
+	f.syntheticChecksReq = req
+	return f.syntheticChecksResp, f.syntheticChecksErr
+}
+
+func (f *fakeClient) SyntheticCheck(_ context.Context, req grafana.SyntheticCheckGetRequest) (any, error) {
+	f.syntheticCheckReq = req
+	return f.syntheticCheckResp, f.syntheticCheckErr
 }
 
 func (f *fakeClient) MetricsRange(_ context.Context, expr, start, end, step string) (any, error) {
@@ -559,6 +609,12 @@ func TestRunHelpAndUnknown(t *testing.T) {
 	}
 	if findCommandByName(t, commands, "schema")["description"] == "" {
 		t.Fatalf("expected schema command in root help")
+	}
+	if findCommandByName(t, commands, "service-accounts")["description"] == "" {
+		t.Fatalf("expected service-accounts command in root help")
+	}
+	if findCommandByName(t, commands, "synthetics")["description"] == "" {
+		t.Fatalf("expected synthetics command in root help")
 	}
 
 	out.Reset()
@@ -1094,6 +1150,183 @@ func TestDashboardFolderAnnotationAndAlertingCommands(t *testing.T) {
 	}
 }
 
+func TestCloudAccessServiceAccountsAndSyntheticsCommands(t *testing.T) {
+	store := &fakeStore{cfg: config.Config{Token: "token"}}
+	client := &fakeClient{
+		cloudAccessResult: map[string]any{
+			"items": []any{map[string]any{"id": "ap-1", "name": "stack-readers"}},
+			"metadata": map[string]any{
+				"pagination": map[string]any{"nextPage": "/v1/accesspolicies?pageCursor=abc"},
+			},
+		},
+		cloudAccessOne:      map[string]any{"id": "ap-1", "name": "stack-readers"},
+		serviceAccountsResp: map[string]any{"totalCount": 3, "serviceAccounts": []any{map[string]any{"id": 1, "name": "grafana"}}, "page": 2, "perPage": 1},
+		serviceAccountResp:  map[string]any{"id": 1, "name": "grafana"},
+		syntheticChecksResp: []any{map[string]any{"id": 123, "job": "checkout"}},
+		syntheticCheckResp:  map[string]any{"id": 123, "job": "checkout"},
+	}
+	app, out, errOut := newTestApp(store, client)
+
+	if code := app.Run(context.Background(), []string{"--agent", "cloud", "access-policies", "list", "--region", "us", "--realm-type", "stack", "--realm-identifier", "123", "--status", "active", "--page-size", "50", "--page-cursor", "cursor-1"}); code != 0 {
+		t.Fatalf("cloud access-policies list should succeed: %s", errOut.String())
+	}
+	if client.cloudAccessReq.Region != "us" || client.cloudAccessReq.RealmType != "stack" || client.cloudAccessReq.RealmIdentifier != "123" || client.cloudAccessReq.Status != "active" || client.cloudAccessReq.PageSize != 50 || client.cloudAccessReq.PageCursor != "cursor-1" {
+		t.Fatalf("unexpected cloud access request: %+v", client.cloudAccessReq)
+	}
+	accessEnvelope := decodeJSON(t, out.String())
+	accessMeta := accessEnvelope["metadata"].(map[string]any)
+	if accessMeta["command"] != "cloud access-policies list" || accessMeta["count"] != float64(1) || accessMeta["truncated"] != true {
+		t.Fatalf("unexpected cloud access metadata: %+v", accessMeta)
+	}
+	if accessMeta["next_action"] == "" {
+		t.Fatalf("expected cloud access next_action")
+	}
+
+	out.Reset()
+	errOut.Reset()
+	if code := app.Run(context.Background(), []string{"cloud", "access-policies", "get", "--id", "ap-1", "--region", "us"}); code != 0 {
+		t.Fatalf("cloud access-policies get should succeed: %s", errOut.String())
+	}
+	if client.cloudAccessID != "ap-1" || client.cloudAccessRegion != "us" {
+		t.Fatalf("unexpected cloud access get args: id=%s region=%s", client.cloudAccessID, client.cloudAccessRegion)
+	}
+	if decodeJSON(t, out.String())["id"] != "ap-1" {
+		t.Fatalf("unexpected access policy get output")
+	}
+
+	out.Reset()
+	errOut.Reset()
+	if code := app.Run(context.Background(), []string{"--agent", "service-accounts", "list", "--query", "graf", "--page", "2", "--limit", "1"}); code != 0 {
+		t.Fatalf("service-accounts list should succeed: %s", errOut.String())
+	}
+	if client.serviceAccountsReq.Query != "graf" || client.serviceAccountsReq.Page != 2 || client.serviceAccountsReq.Limit != 1 {
+		t.Fatalf("unexpected service account request: %+v", client.serviceAccountsReq)
+	}
+	serviceEnvelope := decodeJSON(t, out.String())
+	serviceMeta := serviceEnvelope["metadata"].(map[string]any)
+	if serviceMeta["command"] != "service-accounts list" || serviceMeta["count"] != float64(1) || serviceMeta["truncated"] != true {
+		t.Fatalf("unexpected service account metadata: %+v", serviceMeta)
+	}
+
+	out.Reset()
+	errOut.Reset()
+	if code := app.Run(context.Background(), []string{"service-accounts", "get", "--id", "1"}); code != 0 {
+		t.Fatalf("service-accounts get should succeed: %s", errOut.String())
+	}
+	if client.serviceAccountID != 1 {
+		t.Fatalf("unexpected service account id: %d", client.serviceAccountID)
+	}
+	if decodeJSON(t, out.String())["id"] != float64(1) {
+		t.Fatalf("unexpected service account get output")
+	}
+
+	out.Reset()
+	errOut.Reset()
+	if code := app.Run(context.Background(), []string{"synthetics", "checks", "list", "--backend-url", "synthetic-monitoring-api-us-east-0.grafana.net", "--token", "sm-token", "--include-alerts"}); code != 0 {
+		t.Fatalf("synthetics checks list should succeed: %s", errOut.String())
+	}
+	if client.syntheticChecksReq.BackendURL != "synthetic-monitoring-api-us-east-0.grafana.net" || client.syntheticChecksReq.Token != "sm-token" || !client.syntheticChecksReq.IncludeAlerts {
+		t.Fatalf("unexpected synthetic checks request: %+v", client.syntheticChecksReq)
+	}
+	if len(decodeJSONArray(t, out.String())) != 1 {
+		t.Fatalf("expected one synthetic check in output")
+	}
+
+	t.Setenv("GRAFANA_SYNTHETICS_BACKEND_URL", "synthetic-monitoring-api-eu-west-0.grafana.net")
+	t.Setenv("GRAFANA_SYNTHETICS_TOKEN", "env-token")
+	out.Reset()
+	errOut.Reset()
+	if code := app.Run(context.Background(), []string{"synthetics", "checks", "get", "--id", "123"}); code != 0 {
+		t.Fatalf("synthetics checks get should succeed with env auth: %s", errOut.String())
+	}
+	if client.syntheticCheckReq.BackendURL != "synthetic-monitoring-api-eu-west-0.grafana.net" || client.syntheticCheckReq.Token != "env-token" || client.syntheticCheckReq.ID != 123 {
+		t.Fatalf("unexpected synthetic check request: %+v", client.syntheticCheckReq)
+	}
+	if decodeJSON(t, out.String())["id"] != float64(123) {
+		t.Fatalf("unexpected synthetic check get output")
+	}
+}
+
+func TestCloudAccessServiceAccountsAndSyntheticsValidation(t *testing.T) {
+	store := &fakeStore{cfg: config.Config{Token: "token"}}
+	client := &fakeClient{}
+	app, out, errOut := newTestApp(store, client)
+
+	for _, args := range [][]string{
+		{"cloud", "access-policies", "list"},
+		{"cloud", "access-policies", "list", "--bad"},
+		{"cloud", "access-policies", "list", "--region", "us", "--page-size", "0"},
+		{"cloud", "access-policies", "list", "--region", "us", "--realm-identifier", "123"},
+		{"cloud", "access-policies", "list", "--region", "us", "--realm-type", "team"},
+		{"cloud", "access-policies", "list", "--region", "us", "--status", "paused"},
+		{"cloud", "access-policies", "get", "--bad"},
+		{"cloud", "access-policies", "get", "--region", "us"},
+		{"cloud", "access-policies", "get", "--id", "ap-1"},
+		{"cloud", "access-policies", "bad"},
+		{"service-accounts", "list", "--page", "0"},
+		{"service-accounts", "list", "--bad"},
+		{"service-accounts", "list", "--limit", "0"},
+		{"service-accounts", "get", "--bad"},
+		{"service-accounts", "get", "--id", "0"},
+		{"service-accounts", "bad"},
+		{"synthetics", "bad"},
+		{"synthetics", "bad", "list"},
+		{"synthetics", "checks"},
+		{"synthetics", "checks", "list"},
+		{"synthetics", "checks", "list", "--bad"},
+		{"synthetics", "checks", "get", "--id", "0"},
+		{"synthetics", "checks", "get", "--bad"},
+		{"synthetics", "checks", "bad"},
+	} {
+		out.Reset()
+		errOut.Reset()
+		if code := app.Run(context.Background(), args); code != 1 {
+			t.Fatalf("expected failure for %v", args)
+		}
+	}
+
+	out.Reset()
+	if code := app.Run(context.Background(), []string{"cloud", "access-policies"}); code != 0 {
+		t.Fatalf("cloud access-policies root help should succeed")
+	}
+	if _, ok := decodeJSON(t, out.String())["commands"]; !ok {
+		t.Fatalf("expected cloud access-policies root help output")
+	}
+
+	out.Reset()
+	if code := app.Run(context.Background(), []string{"cloud", "access-policies", "--help"}); code != 0 {
+		t.Fatalf("cloud access-policies help should succeed")
+	}
+	if _, ok := decodeJSON(t, out.String())["commands"]; !ok {
+		t.Fatalf("expected cloud access-policies help output")
+	}
+
+	out.Reset()
+	if code := app.Run(context.Background(), []string{"service-accounts"}); code != 0 {
+		t.Fatalf("service-accounts help should succeed")
+	}
+	if _, ok := decodeJSON(t, out.String())["commands"]; !ok {
+		t.Fatalf("expected service-accounts help output")
+	}
+
+	out.Reset()
+	if code := app.Run(context.Background(), []string{"synthetics"}); code != 0 {
+		t.Fatalf("synthetics help should succeed")
+	}
+	if _, ok := decodeJSON(t, out.String())["commands"]; !ok {
+		t.Fatalf("expected synthetics help output")
+	}
+
+	out.Reset()
+	errOut.Reset()
+	if code := app.Run(context.Background(), []string{"synthetics", "checks", "list", "--backend-url", "synthetic-monitoring-api-us-east-0.grafana.net"}); code != 1 {
+		t.Fatalf("synthetics checks list missing token should fail")
+	}
+	if !strings.Contains(errOut.String(), "--token is required") {
+		t.Fatalf("expected synthetic token validation error, got %s", errOut.String())
+	}
+}
+
 func TestGroupHelpWithoutAuth(t *testing.T) {
 	store := &fakeContextStore{
 		current: "default",
@@ -1107,12 +1340,14 @@ func TestGroupHelpWithoutAuth(t *testing.T) {
 		{"context", "-help"},
 		{"config", "-help"},
 		{"cloud", "-help"},
+		{"service-accounts", "-help"},
 		{"dashboards", "-help"},
 		{"datasources", "-help"},
 		{"folders", "-help"},
 		{"annotations", "-help"},
 		{"alerting", "-help"},
 		{"assistant", "-help"},
+		{"synthetics", "-help"},
 		{"runtime", "-help"},
 		{"aggregate", "-help"},
 		{"incident", "-help"},
@@ -1945,6 +2180,25 @@ func TestAssistantCommands(t *testing.T) {
 	}
 
 	out.Reset()
+	errOut.Reset()
+	if code := app.Run(context.Background(), []string{"--agent", "assistant", "investigate", "--goal", "Investigate checkout latency spike"}); code != 0 {
+		t.Fatalf("assistant investigate should succeed: %s", errOut.String())
+	}
+	if !strings.Contains(client.assistantPrompt, "Goal: Investigate checkout latency spike") {
+		t.Fatalf("assistant investigate prompt not shaped for investigations: %s", client.assistantPrompt)
+	}
+	investigateEnvelope := decodeJSON(t, out.String())
+	if investigateEnvelope["metadata"].(map[string]any)["command"] != "assistant investigate" {
+		t.Fatalf("unexpected assistant investigate metadata: %+v", investigateEnvelope)
+	}
+	if investigateEnvelope["metadata"].(map[string]any)["next_action"] == "" {
+		t.Fatalf("expected assistant investigate next_action")
+	}
+	if investigateEnvelope["data"].(map[string]any)["goal"] != "Investigate checkout latency spike" {
+		t.Fatalf("unexpected assistant investigate payload: %+v", investigateEnvelope["data"])
+	}
+
+	out.Reset()
 	if code := app.Run(context.Background(), []string{"assistant", "status", "--chat-id", "c1"}); code != 0 {
 		t.Fatalf("assistant status should succeed")
 	}
@@ -1975,6 +2229,12 @@ func TestAssistantCommands(t *testing.T) {
 	}
 	if code := app.Run(context.Background(), []string{"assistant", "chat", "--bad"}); code != 1 {
 		t.Fatalf("assistant chat parse should fail")
+	}
+	if code := app.Run(context.Background(), []string{"assistant", "investigate"}); code != 1 {
+		t.Fatalf("assistant investigate missing goal should fail")
+	}
+	if code := app.Run(context.Background(), []string{"assistant", "investigate", "--bad"}); code != 1 {
+		t.Fatalf("assistant investigate parse should fail")
 	}
 	if code := app.Run(context.Background(), []string{"assistant", "status"}); code != 1 {
 		t.Fatalf("assistant status missing chat id should fail")
@@ -2419,6 +2679,12 @@ func TestAppErrorBranches(t *testing.T) {
 	if code := app.Run(context.Background(), []string{"dashboards", "list"}); code != 1 {
 		t.Fatalf("expected dashboards auth error")
 	}
+	if code := app.Run(context.Background(), []string{"service-accounts", "list"}); code != 1 {
+		t.Fatalf("expected service-accounts auth error")
+	}
+	if code := app.Run(context.Background(), []string{"cloud", "access-policies", "list", "--region", "us"}); code != 1 {
+		t.Fatalf("expected cloud access-policies auth error")
+	}
 
 	// runDashboards list and create client error branches + create parse error.
 	store = &fakeStore{cfg: config.Config{Token: "x"}}
@@ -2448,6 +2714,26 @@ func TestAppErrorBranches(t *testing.T) {
 	if code := app.Run(context.Background(), []string{"datasources", "list"}); code != 1 {
 		t.Fatalf("expected datasources client error")
 	}
+	client = &fakeClient{serviceAccountsErr: errors.New("service accounts fail")}
+	app, _, _ = newTestApp(store, client)
+	if code := app.Run(context.Background(), []string{"service-accounts", "list"}); code != 1 {
+		t.Fatalf("expected service-accounts client error")
+	}
+	client = &fakeClient{serviceAccountErr: errors.New("service account fail")}
+	app, _, _ = newTestApp(store, client)
+	if code := app.Run(context.Background(), []string{"service-accounts", "get", "--id", "1"}); code != 1 {
+		t.Fatalf("expected service-account get client error")
+	}
+	client = &fakeClient{cloudAccessErr: errors.New("cloud access fail")}
+	app, _, _ = newTestApp(store, client)
+	if code := app.Run(context.Background(), []string{"cloud", "access-policies", "list", "--region", "us"}); code != 1 {
+		t.Fatalf("expected cloud access-policies client error")
+	}
+	client = &fakeClient{cloudAccessOneErr: errors.New("cloud access get fail")}
+	app, _, _ = newTestApp(store, client)
+	if code := app.Run(context.Background(), []string{"cloud", "access-policies", "get", "--id", "ap-1", "--region", "us"}); code != 1 {
+		t.Fatalf("expected cloud access-policy get client error")
+	}
 
 	// runAssistant auth + client error branches.
 	store = &fakeStore{cfg: config.Config{}}
@@ -2472,6 +2758,11 @@ func TestAppErrorBranches(t *testing.T) {
 	if code := app.Run(context.Background(), []string{"assistant", "skills"}); code != 1 {
 		t.Fatalf("expected assistant skills client error")
 	}
+	client.assistantSkillsErr = nil
+	client.assistantChatErr = errors.New("assistant investigate fail")
+	if code := app.Run(context.Background(), []string{"assistant", "investigate", "--goal", "x"}); code != 1 {
+		t.Fatalf("expected assistant investigate client error")
+	}
 
 	// runRuntime auth + client error branches.
 	store = &fakeStore{cfg: config.Config{}}
@@ -2495,6 +2786,18 @@ func TestAppErrorBranches(t *testing.T) {
 	client.tracesErr = errors.New("traces fail")
 	if code := app.Run(context.Background(), []string{"runtime", "traces", "search", "--query", "{}"}); code != 1 {
 		t.Fatalf("expected runtime traces client error")
+	}
+
+	// runSynthetics client error branches.
+	client = &fakeClient{syntheticChecksErr: errors.New("synthetics fail")}
+	app, _, _ = newTestApp(store, client)
+	if code := app.Run(context.Background(), []string{"synthetics", "checks", "list", "--backend-url", "synthetic-monitoring-api-us-east-0.grafana.net", "--token", "sm-token"}); code != 1 {
+		t.Fatalf("expected synthetics list client error")
+	}
+	client = &fakeClient{syntheticCheckErr: errors.New("synthetic check fail")}
+	app, _, _ = newTestApp(store, client)
+	if code := app.Run(context.Background(), []string{"synthetics", "checks", "get", "--backend-url", "synthetic-monitoring-api-us-east-0.grafana.net", "--token", "sm-token", "--id", "1"}); code != 1 {
+		t.Fatalf("expected synthetic check client error")
 	}
 
 	// runAggregate auth + aggregate error branches.
@@ -2756,8 +3059,40 @@ func TestHelpers(t *testing.T) {
 	if !payloadHasNextPage(map[string]any{"next": "https://next"}) {
 		t.Fatalf("expected payloadHasNextPage to detect next page")
 	}
+	if !payloadHasNextPage(map[string]any{"metadata": map[string]any{"pagination": map[string]any{"nextPage": "/v1/accesspolicies?pageCursor=abc"}}}) {
+		t.Fatalf("expected payloadHasNextPage to detect nested next page")
+	}
 	if payloadHasNextPage([]any{1}) {
 		t.Fatalf("expected payloadHasNextPage to ignore non-map payloads")
+	}
+	if got := mapValue(map[string]any{"a": map[string]any{"b": map[string]any{"c": "d"}}}, "a", "b")["c"]; got != "d" {
+		t.Fatalf("unexpected mapValue result: %+v", got)
+	}
+	if mapValue(map[string]any{"a": 1}, "a") != nil {
+		t.Fatalf("expected nil mapValue for non-map leaf")
+	}
+	if mapValue("scalar", "a") != nil {
+		t.Fatalf("expected nil mapValue for non-map root")
+	}
+	if !strings.Contains(investigationPrompt("Investigate checkout latency"), "Goal: Investigate checkout latency") {
+		t.Fatalf("expected investigationPrompt to embed the goal")
+	}
+	t.Setenv("GRAFANA_SYNTHETICS_BACKEND_URL", "synthetic-monitoring-api-us-east-0.grafana.net")
+	t.Setenv("GRAFANA_SYNTHETICS_TOKEN", "sm-token")
+	if backendURL, token, err := resolveSyntheticsAuth("", ""); err != nil || backendURL != "synthetic-monitoring-api-us-east-0.grafana.net" || token != "sm-token" {
+		t.Fatalf("unexpected resolved synthetics auth: backend=%s token=%s err=%v", backendURL, token, err)
+	}
+	if _, _, err := resolveSyntheticsAuth("", ""); err != nil {
+		// keep env-backed path covered before clearing for the negative assertions below
+		t.Fatalf("expected env-backed resolveSyntheticsAuth to succeed: %v", err)
+	}
+	t.Setenv("GRAFANA_SYNTHETICS_BACKEND_URL", "")
+	t.Setenv("GRAFANA_SYNTHETICS_TOKEN", "")
+	if _, _, err := resolveSyntheticsAuth("", ""); err == nil {
+		t.Fatalf("expected missing synthetics auth error")
+	}
+	if _, err := syntheticCheckGetRequest("", "", 7); err == nil {
+		t.Fatalf("expected syntheticCheckGetRequest error when auth is missing")
 	}
 }
 

--- a/internal/cli/cloud_access.go
+++ b/internal/cli/cloud_access.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"io"
+	"strings"
+
+	"github.com/matiasvillaverde/grafana-cli/internal/grafana"
+)
+
+func (a *App) runCloudAccessPolicies(ctx context.Context, opts globalOptions, args []string) error {
+	if len(args) == 0 || isHelpArg(args[0]) {
+		return a.emitHelp(opts, []string{"cloud", "access-policies"}, true)
+	}
+
+	cfg, err := a.requireAuthConfig()
+	if err != nil {
+		return err
+	}
+	client := a.NewClient(cfg)
+
+	switch args[0] {
+	case "list":
+		fs := flag.NewFlagSet("cloud access-policies list", flag.ContinueOnError)
+		fs.SetOutput(io.Discard)
+		name := fs.String("name", "", "access policy name filter")
+		realmType := fs.String("realm-type", "", "realm type: org or stack")
+		realmIdentifier := fs.String("realm-identifier", "", "realm identifier")
+		pageSize := fs.Int("page-size", 100, "page size")
+		pageCursor := fs.String("page-cursor", "", "cursor for the next page")
+		region := fs.String("region", "", "access policy region")
+		status := fs.String("status", "", "policy status: active or inactive")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if strings.TrimSpace(*region) == "" {
+			return errors.New("--region is required")
+		}
+		if *pageSize < 1 {
+			return errors.New("--page-size must be at least 1")
+		}
+		if strings.TrimSpace(*realmIdentifier) != "" && strings.TrimSpace(*realmType) == "" {
+			return errors.New("--realm-type is required when --realm-identifier is set")
+		}
+		if strings.TrimSpace(*realmType) != "" && *realmType != "org" && *realmType != "stack" {
+			return errors.New("--realm-type must be org or stack")
+		}
+		if strings.TrimSpace(*status) != "" && *status != "active" && *status != "inactive" {
+			return errors.New("--status must be active or inactive")
+		}
+		result, err := client.CloudAccessPolicies(ctx, grafana.CloudAccessPolicyListRequest{
+			Name:            strings.TrimSpace(*name),
+			RealmType:       strings.TrimSpace(*realmType),
+			RealmIdentifier: strings.TrimSpace(*realmIdentifier),
+			PageSize:        *pageSize,
+			PageCursor:      strings.TrimSpace(*pageCursor),
+			Region:          strings.TrimSpace(*region),
+			Status:          strings.TrimSpace(*status),
+		})
+		if err != nil {
+			return err
+		}
+		return a.emitWithMetadata(opts, result, accessPolicyMetadata(result))
+	case "get":
+		fs := flag.NewFlagSet("cloud access-policies get", flag.ContinueOnError)
+		fs.SetOutput(io.Discard)
+		id := fs.String("id", "", "access policy ID")
+		region := fs.String("region", "", "access policy region")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if strings.TrimSpace(*id) == "" {
+			return errors.New("--id is required")
+		}
+		if strings.TrimSpace(*region) == "" {
+			return errors.New("--region is required")
+		}
+		result, err := client.CloudAccessPolicy(ctx, strings.TrimSpace(*id), strings.TrimSpace(*region))
+		if err != nil {
+			return err
+		}
+		return a.emit(opts, result)
+	default:
+		return errors.New("usage: cloud access-policies <list|get> [flags]")
+	}
+}
+
+func accessPolicyMetadata(payload any) *responseMetadata {
+	meta := &responseMetadata{Command: "cloud access-policies list"}
+	if count := countPath(payload, "items"); count > 0 {
+		meta.Count = &count
+	}
+	if payloadHasNextPage(payload) {
+		meta.Truncated = true
+		meta.NextAction = "Use --page-cursor to continue listing access policies"
+	}
+	return meta
+}

--- a/internal/cli/discovery.go
+++ b/internal/cli/discovery.go
@@ -163,6 +163,24 @@ func discoveryCatalog() []discoveryCommand {
 						{Name: "list", Description: "List available Grafana Cloud stacks", ReadOnly: true, Examples: []string{"grafana cloud stacks list"}, OutputShape: `{"items":[...]}`, RelatedCommands: []string{"auth doctor", "context list"}, TokenCost: "small"},
 					},
 				},
+				{
+					Name:        "access-policies",
+					Description: "Inspect Cloud access policies",
+					ReadOnly:    true,
+					Subcommands: []discoveryCommand{
+						{Name: "list", Description: "List access policies", ReadOnly: true, Flags: []discoveryFlag{{Name: "--region", Type: "string", Description: "Policy region"}, {Name: "--name", Type: "string", Description: "Name filter"}, {Name: "--realm-type", Type: "string", Description: "org or stack"}, {Name: "--realm-identifier", Type: "string", Description: "Realm ID"}, {Name: "--status", Type: "string", Description: "active or inactive"}, {Name: "--page-size", Type: "int", Default: 100, Description: "Page size"}, {Name: "--page-cursor", Type: "string", Description: "Page cursor"}}, Examples: []string{`grafana cloud access-policies list --region us`, `grafana cloud access-policies list --region eu --realm-type stack --realm-identifier 12345`}, OutputShape: `{"items":[{"id":"uuid","name":"stack-readers"}],"metadata":{"pagination":{"nextPage":"/v1/accesspolicies?pageCursor=..."}}}`, RelatedCommands: []string{"cloud access-policies get", "service-accounts list"}, TokenCost: "small"},
+						{Name: "get", Description: "Get one access policy", ReadOnly: true, Flags: []discoveryFlag{{Name: "--id", Type: "string", Description: "Policy ID"}, {Name: "--region", Type: "string", Description: "Policy region"}}, Examples: []string{`grafana cloud access-policies get --id c45485b6-8321-4cf2-bcec-12006df755ff --region us`}, OutputShape: `{"id":"uuid","name":"stack-readers","scopes":["metrics:read"]}`, RelatedCommands: []string{"cloud access-policies list", "auth doctor"}, TokenCost: "small"},
+					},
+				},
+			},
+		},
+		{
+			Name:        "service-accounts",
+			Description: "Inspect service accounts",
+			ReadOnly:    true,
+			Subcommands: []discoveryCommand{
+				{Name: "list", Description: "List service accounts", ReadOnly: true, Flags: []discoveryFlag{{Name: "--query", Type: "string", Description: "Name filter"}, {Name: "--page", Type: "int", Default: 1, Description: "Page"}, {Name: "--limit", Type: "int", Default: 100, Description: "Page size"}}, Examples: []string{`grafana service-accounts list`, `grafana service-accounts list --query writer --page 2 --limit 20`}, OutputShape: `{"totalCount":2,"serviceAccounts":[{"id":1,"name":"grafana"}],"page":1,"perPage":10}`, RelatedCommands: []string{"service-accounts get", "cloud access-policies list"}, TokenCost: "small"},
+				{Name: "get", Description: "Get one service account", ReadOnly: true, Flags: []discoveryFlag{{Name: "--id", Type: "int", Description: "Service account ID"}}, Examples: []string{`grafana service-accounts get --id 1`}, OutputShape: `{"id":1,"name":"grafana","tokens":0}`, RelatedCommands: []string{"service-accounts list", "auth doctor"}, TokenCost: "small"},
 			},
 		},
 		{
@@ -251,8 +269,20 @@ func discoveryCatalog() []discoveryCommand {
 			ReadOnly:    false,
 			Subcommands: []discoveryCommand{
 				{Name: "chat", Description: "Send a prompt to Grafana Assistant", ReadOnly: false, Flags: []discoveryFlag{{Name: "--prompt", Type: "string", Description: "Assistant prompt"}, {Name: "--chat-id", Type: "string", Description: "Existing chat ID"}}, Examples: []string{`grafana assistant chat --prompt "Investigate elevated error rate"`}, OutputShape: `{"chatId":"chat_123"}`, RelatedCommands: []string{"assistant status", "assistant skills"}, TokenCost: "medium"},
+				{Name: "investigate", Description: "Start an assistant investigation", ReadOnly: false, Flags: []discoveryFlag{{Name: "--goal", Type: "string", Description: "Investigation goal"}, {Name: "--chat-id", Type: "string", Description: "Existing chat ID"}}, Examples: []string{`grafana assistant investigate --goal "Investigate checkout latency spike"`}, OutputShape: `{"goal":"Investigate checkout latency spike","chat":{"chatId":"chat_123"}}`, RelatedCommands: []string{"assistant status", "incident analyze", "runtime logs query"}, TokenCost: "medium"},
 				{Name: "status", Description: "Poll Assistant chat status", ReadOnly: true, Flags: []discoveryFlag{{Name: "--chat-id", Type: "string", Description: "Chat ID"}}, Examples: []string{"grafana assistant status --chat-id chat_123"}, OutputShape: `{"status":"completed"}`, RelatedCommands: []string{"assistant chat", "assistant skills"}, TokenCost: "small"},
 				{Name: "skills", Description: "List Assistant skills", ReadOnly: true, Examples: []string{"grafana assistant skills"}, OutputShape: `{"items":[...]}`, RelatedCommands: []string{"assistant chat", "incident analyze"}, TokenCost: "small"},
+			},
+		},
+		{
+			Name:        "synthetics",
+			Description: "Inspect Synthetic Monitoring checks",
+			ReadOnly:    true,
+			Subcommands: []discoveryCommand{
+				{Name: "checks", Description: "Inspect Synthetic Monitoring checks", ReadOnly: true, Subcommands: []discoveryCommand{
+					{Name: "list", Description: "List checks", ReadOnly: true, Flags: []discoveryFlag{{Name: "--backend-url", Type: "string", Description: "Backend address"}, {Name: "--token", Type: "string", Description: "Access token"}, {Name: "--include-alerts", Type: "bool", Default: false, Description: "Include alerts"}}, Examples: []string{`grafana synthetics checks list --backend-url synthetic-monitoring-api-us-east-0.grafana.net --token "$GRAFANA_SYNTHETICS_TOKEN"`}, OutputShape: `[{"id":123,"job":"checkout"}]`, RelatedCommands: []string{"synthetics checks get", "assistant investigate"}, TokenCost: "small"},
+					{Name: "get", Description: "Get one check", ReadOnly: true, Flags: []discoveryFlag{{Name: "--backend-url", Type: "string", Description: "Backend address"}, {Name: "--token", Type: "string", Description: "Access token"}, {Name: "--id", Type: "int", Description: "Check ID"}}, Examples: []string{`grafana synthetics checks get --backend-url synthetic-monitoring-api-us-east-0.grafana.net --token "$GRAFANA_SYNTHETICS_TOKEN" --id 123`}, OutputShape: `{"check":{"id":123,"job":"checkout"}}`, RelatedCommands: []string{"synthetics checks list", "runtime metrics query"}, TokenCost: "small"},
+				}},
 			},
 		},
 		{
@@ -477,6 +507,11 @@ func buildDiscoveryPayload(path []string, compact bool) (map[string]any, error) 
 		}
 		commandPayloads = append(commandPayloads, fullCommandPayload(command, nil))
 	}
+	if compact && len(path) == 0 {
+		for _, payload := range commandPayloads {
+			trimCompactRootPayload(payload)
+		}
+	}
 
 	payload := map[string]any{
 		"version":      cliVersion,
@@ -502,6 +537,17 @@ func buildDiscoveryPayload(path []string, compact bool) (map[string]any, error) 
 		}
 	}
 	return payload, nil
+}
+
+func trimCompactRootPayload(payload map[string]any) {
+	delete(payload, "flags")
+	children, ok := payload["subcommands"].([]map[string]any)
+	if !ok {
+		return
+	}
+	for _, child := range children {
+		trimCompactRootPayload(child)
+	}
 }
 
 func findDiscoveryCommand(commands []discoveryCommand, path []string) (discoveryCommand, bool) {

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -1,0 +1,36 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+)
+
+func mapValue(payload any, path ...string) map[string]any {
+	current, ok := payload.(map[string]any)
+	if !ok {
+		return nil
+	}
+	for _, key := range path {
+		next, ok := current[key].(map[string]any)
+		if !ok {
+			return nil
+		}
+		current = next
+	}
+	return current
+}
+
+func investigationPrompt(goal string) string {
+	return strings.TrimSpace(fmt.Sprintf(`
+Investigate the following operational issue in Grafana.
+
+Goal: %s
+
+Respond with:
+1. the most likely impacted services, dashboards, or signals
+2. the next concrete Grafana queries or views to inspect
+3. the top hypotheses and evidence gaps
+
+Keep the answer concise, evidence-first, and operational.
+`, strings.TrimSpace(goal)))
+}

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -22,7 +22,7 @@ type responseEnvelope struct {
 	Metadata *responseMetadata `json:"metadata,omitempty"`
 }
 
-var collectionKeys = []string{"items", "data", "results", "result", "traces", "queryHistory", "slos"}
+var collectionKeys = []string{"items", "data", "results", "result", "traces", "queryHistory", "slos", "serviceAccounts"}
 
 func withCommandMetadata(meta *responseMetadata, command string) *responseMetadata {
 	if meta == nil {

--- a/internal/cli/service_accounts.go
+++ b/internal/cli/service_accounts.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"io"
+	"strings"
+
+	"github.com/matiasvillaverde/grafana-cli/internal/grafana"
+)
+
+func (a *App) runServiceAccounts(ctx context.Context, opts globalOptions, args []string) error {
+	if len(args) == 0 || isHelpArg(args[0]) {
+		return a.emitHelp(opts, []string{"service-accounts"}, true)
+	}
+
+	cfg, err := a.requireAuthConfig()
+	if err != nil {
+		return err
+	}
+	client := a.NewClient(cfg)
+
+	switch args[0] {
+	case "list":
+		fs := flag.NewFlagSet("service-accounts list", flag.ContinueOnError)
+		fs.SetOutput(io.Discard)
+		query := fs.String("query", "", "service account name filter")
+		page := fs.Int("page", 1, "page number")
+		limit := fs.Int("limit", 100, "page size")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if *page < 1 {
+			return errors.New("--page must be at least 1")
+		}
+		if *limit < 1 {
+			return errors.New("--limit must be at least 1")
+		}
+		result, err := client.ServiceAccounts(ctx, grafana.ServiceAccountListRequest{
+			Query: strings.TrimSpace(*query),
+			Page:  *page,
+			Limit: *limit,
+		})
+		if err != nil {
+			return err
+		}
+		return a.emitWithMetadata(opts, result, serviceAccountMetadata(result))
+	case "get":
+		fs := flag.NewFlagSet("service-accounts get", flag.ContinueOnError)
+		fs.SetOutput(io.Discard)
+		id := fs.Int64("id", 0, "service account ID")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if *id < 1 {
+			return errors.New("--id must be at least 1")
+		}
+		result, err := client.ServiceAccount(ctx, *id)
+		if err != nil {
+			return err
+		}
+		return a.emit(opts, result)
+	default:
+		return errors.New("usage: service-accounts <list|get> [flags]")
+	}
+}
+
+func serviceAccountMetadata(payload any) *responseMetadata {
+	meta := &responseMetadata{Command: "service-accounts list"}
+	if count := countPath(payload, "serviceAccounts"); count > 0 {
+		meta.Count = &count
+	}
+	if totalCount, ok := intPath(payload, "totalCount"); ok && meta.Count != nil && totalCount > *meta.Count {
+		meta.Truncated = true
+		meta.NextAction = "Use --page to inspect more service accounts or narrow --query"
+	}
+	return meta
+}

--- a/internal/cli/synthetics.go
+++ b/internal/cli/synthetics.go
@@ -1,0 +1,110 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/matiasvillaverde/grafana-cli/internal/config"
+	"github.com/matiasvillaverde/grafana-cli/internal/grafana"
+)
+
+func (a *App) runSynthetics(ctx context.Context, opts globalOptions, args []string) error {
+	if len(args) == 0 || isHelpArg(args[0]) {
+		return a.emitHelp(opts, []string{"synthetics"}, true)
+	}
+	if len(args) < 2 || args[0] != "checks" {
+		return errors.New("usage: synthetics checks <list|get> [flags]")
+	}
+
+	client := a.NewClient(config.Config{})
+
+	switch args[1] {
+	case "list":
+		fs := flag.NewFlagSet("synthetics checks list", flag.ContinueOnError)
+		fs.SetOutput(io.Discard)
+		backendURL := fs.String("backend-url", "", "Synthetic Monitoring backend address")
+		token := fs.String("token", "", "Synthetic Monitoring access token")
+		includeAlerts := fs.Bool("include-alerts", false, "include alert definitions")
+		if err := fs.Parse(args[2:]); err != nil {
+			return err
+		}
+		req, err := syntheticCheckListRequest(*backendURL, *token, *includeAlerts)
+		if err != nil {
+			return err
+		}
+		result, err := client.SyntheticChecks(ctx, req)
+		if err != nil {
+			return err
+		}
+		return a.emitWithMetadata(opts, result, collectionMetadata("synthetics checks list", result, 0, ""))
+	case "get":
+		fs := flag.NewFlagSet("synthetics checks get", flag.ContinueOnError)
+		fs.SetOutput(io.Discard)
+		backendURL := fs.String("backend-url", "", "Synthetic Monitoring backend address")
+		token := fs.String("token", "", "Synthetic Monitoring access token")
+		id := fs.Int64("id", 0, "synthetic check ID")
+		if err := fs.Parse(args[2:]); err != nil {
+			return err
+		}
+		if *id < 1 {
+			return errors.New("--id must be at least 1")
+		}
+		req, err := syntheticCheckGetRequest(*backendURL, *token, *id)
+		if err != nil {
+			return err
+		}
+		result, err := client.SyntheticCheck(ctx, req)
+		if err != nil {
+			return err
+		}
+		return a.emit(opts, result)
+	default:
+		return errors.New("usage: synthetics checks <list|get> [flags]")
+	}
+}
+
+func syntheticCheckListRequest(backendURL, token string, includeAlerts bool) (grafana.SyntheticCheckListRequest, error) {
+	resolvedBackendURL, resolvedToken, err := resolveSyntheticsAuth(backendURL, token)
+	if err != nil {
+		return grafana.SyntheticCheckListRequest{}, err
+	}
+	return grafana.SyntheticCheckListRequest{
+		BackendURL:    resolvedBackendURL,
+		Token:         resolvedToken,
+		IncludeAlerts: includeAlerts,
+	}, nil
+}
+
+func syntheticCheckGetRequest(backendURL, token string, id int64) (grafana.SyntheticCheckGetRequest, error) {
+	resolvedBackendURL, resolvedToken, err := resolveSyntheticsAuth(backendURL, token)
+	if err != nil {
+		return grafana.SyntheticCheckGetRequest{}, err
+	}
+	return grafana.SyntheticCheckGetRequest{
+		BackendURL: resolvedBackendURL,
+		Token:      resolvedToken,
+		ID:         id,
+	}, nil
+}
+
+func resolveSyntheticsAuth(backendURL, token string) (string, string, error) {
+	resolvedBackendURL := strings.TrimSpace(backendURL)
+	if resolvedBackendURL == "" {
+		resolvedBackendURL = strings.TrimSpace(os.Getenv("GRAFANA_SYNTHETICS_BACKEND_URL"))
+	}
+	if resolvedBackendURL == "" {
+		return "", "", errors.New("--backend-url is required or set GRAFANA_SYNTHETICS_BACKEND_URL")
+	}
+	resolvedToken := strings.TrimSpace(token)
+	if resolvedToken == "" {
+		resolvedToken = strings.TrimSpace(os.Getenv("GRAFANA_SYNTHETICS_TOKEN"))
+	}
+	if resolvedToken == "" {
+		return "", "", errors.New("--token is required or set GRAFANA_SYNTHETICS_TOKEN")
+	}
+	return resolvedBackendURL, resolvedToken, nil
+}

--- a/internal/grafana/client.go
+++ b/internal/grafana/client.go
@@ -492,7 +492,27 @@ func (c *Client) requestJSON(ctx context.Context, method, endpoint string, body 
 	return out, nil
 }
 
+func (c *Client) requestJSONWithAuth(ctx context.Context, method, endpoint string, body any, token string, orgID int64) (any, error) {
+	data, _, err := c.requestBytesWithAuth(ctx, method, endpoint, body, "application/json", token, orgID)
+	if err != nil {
+		return nil, err
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return map[string]any{}, nil
+	}
+
+	var out any
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *Client) requestBytes(ctx context.Context, method, endpoint string, body any, accept string) ([]byte, http.Header, error) {
+	return c.requestBytesWithAuth(ctx, method, endpoint, body, accept, c.cfg.Token, c.cfg.OrgID)
+}
+
+func (c *Client) requestBytesWithAuth(ctx context.Context, method, endpoint string, body any, accept, token string, orgID int64) ([]byte, http.Header, error) {
 	var reader io.Reader
 	if body != nil {
 		data, err := json.Marshal(body)
@@ -514,11 +534,11 @@ func (c *Client) requestBytes(ctx context.Context, method, endpoint string, body
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	if strings.TrimSpace(c.cfg.Token) != "" {
-		req.Header.Set("Authorization", "Bearer "+c.cfg.Token)
+	if strings.TrimSpace(token) != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
 	}
-	if c.cfg.OrgID > 0 {
-		req.Header.Set("X-Grafana-Org-Id", strconv.FormatInt(c.cfg.OrgID, 10))
+	if orgID > 0 {
+		req.Header.Set("X-Grafana-Org-Id", strconv.FormatInt(orgID, 10))
 	}
 
 	resp, err := c.doer.Do(req)

--- a/internal/grafana/client_test.go
+++ b/internal/grafana/client_test.go
@@ -95,6 +95,15 @@ func TestClientDomainMethods(t *testing.T) {
 	hits := make(map[string]int)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		hits[r.URL.Path]++
+		if strings.HasPrefix(r.URL.Path, "/api/v1/check") && r.Header.Get("Authorization") != "Bearer sm-token" {
+			t.Fatalf("missing synthetic monitoring auth header")
+		}
+		if r.URL.Path == "/api/serviceaccounts/search" && r.URL.Query().Get("perpage") != "20" {
+			t.Fatalf("missing service account perpage query: %s", r.URL.RawQuery)
+		}
+		if r.URL.Path == "/api/v1/accesspolicies" && r.URL.Query().Get("region") != "us" {
+			t.Fatalf("missing access policy region query: %s", r.URL.RawQuery)
+		}
 		if r.URL.Path == "/api/search" {
 			if r.URL.Query().Get("q") == "" && r.URL.Query().Get("type") != "dash-db" {
 				t.Fatalf("missing type query")
@@ -120,6 +129,12 @@ func TestClientDomainMethods(t *testing.T) {
 	if _, err := client.CloudStacks(context.Background()); err != nil {
 		t.Fatalf("cloud stacks failed: %v", err)
 	}
+	if _, err := client.CloudAccessPolicies(context.Background(), CloudAccessPolicyListRequest{Region: "us", PageSize: 10}); err != nil {
+		t.Fatalf("cloud access policies failed: %v", err)
+	}
+	if _, err := client.CloudAccessPolicy(context.Background(), "ap-1", "us"); err != nil {
+		t.Fatalf("cloud access policy failed: %v", err)
+	}
 	if _, err := client.SearchDashboards(context.Background(), "errors", "prod", 10); err != nil {
 		t.Fatalf("search dashboards failed: %v", err)
 	}
@@ -128,6 +143,12 @@ func TestClientDomainMethods(t *testing.T) {
 	}
 	if _, err := client.ListDatasources(context.Background()); err != nil {
 		t.Fatalf("list datasources failed: %v", err)
+	}
+	if _, err := client.ServiceAccounts(context.Background(), ServiceAccountListRequest{Query: "graf", Page: 2, Limit: 20}); err != nil {
+		t.Fatalf("service accounts failed: %v", err)
+	}
+	if _, err := client.ServiceAccount(context.Background(), 1); err != nil {
+		t.Fatalf("service account failed: %v", err)
 	}
 	if _, err := client.AssistantChat(context.Background(), "Investigate spike", "chat-1"); err != nil {
 		t.Fatalf("assistant chat failed: %v", err)
@@ -147,9 +168,18 @@ func TestClientDomainMethods(t *testing.T) {
 	if _, err := client.TracesSearch(context.Background(), "{ status = error }", "", "", 5); err != nil {
 		t.Fatalf("traces failed: %v", err)
 	}
+	if _, err := client.SyntheticChecks(context.Background(), SyntheticCheckListRequest{BackendURL: srv.URL, Token: "sm-token", IncludeAlerts: true}); err != nil {
+		t.Fatalf("synthetic checks failed: %v", err)
+	}
+	if _, err := client.SyntheticCheck(context.Background(), SyntheticCheckGetRequest{BackendURL: srv.URL, Token: "sm-token", ID: 123}); err != nil {
+		t.Fatalf("synthetic check failed: %v", err)
+	}
 
-	if hits["/api/v1/stacks"] != 1 || hits["/api/search"] != 2 || hits["/api/dashboards/db"] != 1 || hits["/api/datasources"] != 1 {
+	if hits["/api/v1/stacks"] != 1 || hits["/api/v1/accesspolicies"] != 1 || hits["/api/v1/accesspolicies/ap-1"] != 1 || hits["/api/search"] != 2 || hits["/api/dashboards/db"] != 1 || hits["/api/datasources"] != 1 {
 		t.Fatalf("unexpected hit counts: %+v", hits)
+	}
+	if hits["/api/serviceaccounts/search"] != 1 || hits["/api/serviceaccounts/1"] != 1 {
+		t.Fatalf("expected service account endpoints hit: %+v", hits)
 	}
 	if hits["/api/plugins/grafana-assistant-app/resources/api/v1/assistant/chats"] != 1 {
 		t.Fatalf("expected assistant chat endpoint hit")
@@ -165,6 +195,9 @@ func TestClientDomainMethods(t *testing.T) {
 	}
 	if hits["/api/plugins/grafana-assistant-app/resources/api/v1/assistant/skills"] != 1 {
 		t.Fatalf("expected assistant skills endpoint hit")
+	}
+	if hits["/api/v1/check"] != 1 || hits["/api/v1/check/123"] != 1 {
+		t.Fatalf("expected synthetic check endpoints hit: %+v", hits)
 	}
 	if hits["/api/prom/api/v1/query_range"] != 1 || hits["/loki/api/v1/query_range"] != 1 || hits["/api/search"] < 2 {
 		t.Fatalf("runtime endpoints not hit: %+v", hits)
@@ -198,6 +231,12 @@ func TestClientMissingBaseURLPaths(t *testing.T) {
 	if _, err := client.CloudStacks(context.Background()); !errors.Is(err, ErrMissingBaseURL) {
 		t.Fatalf("expected ErrMissingBaseURL for cloud stacks, got %v", err)
 	}
+	if _, err := client.CloudAccessPolicies(context.Background(), CloudAccessPolicyListRequest{Region: "us"}); !errors.Is(err, ErrMissingBaseURL) {
+		t.Fatalf("expected ErrMissingBaseURL for cloud access policies, got %v", err)
+	}
+	if _, err := client.CloudAccessPolicy(context.Background(), "ap-1", "us"); !errors.Is(err, ErrMissingBaseURL) {
+		t.Fatalf("expected ErrMissingBaseURL for cloud access policy, got %v", err)
+	}
 	if _, err := client.SearchDashboards(context.Background(), "", "", 0); !errors.Is(err, ErrMissingBaseURL) {
 		t.Fatalf("expected ErrMissingBaseURL for search dashboards, got %v", err)
 	}
@@ -225,6 +264,12 @@ func TestClientMissingBaseURLPaths(t *testing.T) {
 	if _, err := client.GetFolder(context.Background(), "x"); !errors.Is(err, ErrMissingBaseURL) {
 		t.Fatalf("expected ErrMissingBaseURL for get folder, got %v", err)
 	}
+	if _, err := client.ServiceAccounts(context.Background(), ServiceAccountListRequest{}); !errors.Is(err, ErrMissingBaseURL) {
+		t.Fatalf("expected ErrMissingBaseURL for service accounts, got %v", err)
+	}
+	if _, err := client.ServiceAccount(context.Background(), 1); !errors.Is(err, ErrMissingBaseURL) {
+		t.Fatalf("expected ErrMissingBaseURL for service account, got %v", err)
+	}
 	if _, err := client.ListAnnotations(context.Background(), AnnotationListRequest{}); !errors.Is(err, ErrMissingBaseURL) {
 		t.Fatalf("expected ErrMissingBaseURL for list annotations, got %v", err)
 	}
@@ -245,6 +290,12 @@ func TestClientMissingBaseURLPaths(t *testing.T) {
 	}
 	if _, err := client.AssistantSkills(context.Background()); !errors.Is(err, ErrMissingBaseURL) {
 		t.Fatalf("expected ErrMissingBaseURL for assistant skills, got %v", err)
+	}
+	if _, err := client.SyntheticChecks(context.Background(), SyntheticCheckListRequest{}); !errors.Is(err, ErrMissingBaseURL) {
+		t.Fatalf("expected ErrMissingBaseURL for synthetic checks, got %v", err)
+	}
+	if _, err := client.SyntheticCheck(context.Background(), SyntheticCheckGetRequest{ID: 1}); !errors.Is(err, ErrMissingBaseURL) {
+		t.Fatalf("expected ErrMissingBaseURL for synthetic check, got %v", err)
 	}
 }
 
@@ -672,6 +723,48 @@ func TestRequestJSONErrorPaths(t *testing.T) {
 	}
 }
 
+func TestRequestJSONWithAuthBranches(t *testing.T) {
+	call := 0
+	client := NewClient(config.Config{BaseURL: "https://grafana.com"}, doerFunc(func(r *http.Request) (*http.Response, error) {
+		if r.Header.Get("Authorization") != "Bearer explicit-token" {
+			t.Fatalf("expected explicit auth token")
+		}
+		call++
+		switch call {
+		case 1:
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("")),
+				Header:     make(http.Header),
+			}, nil
+		default:
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("{")),
+				Header:     make(http.Header),
+			}, nil
+		}
+	}))
+
+	resp, err := client.requestJSONWithAuth(context.Background(), http.MethodGet, "https://grafana.com", nil, "explicit-token", 0)
+	if err != nil {
+		t.Fatalf("expected empty-body success, got %v", err)
+	}
+	if _, ok := resp.(map[string]any); !ok {
+		t.Fatalf("expected empty object response")
+	}
+	if _, err := client.requestJSONWithAuth(context.Background(), http.MethodGet, "https://grafana.com", nil, "explicit-token", 0); err == nil {
+		t.Fatalf("expected invalid JSON error")
+	}
+
+	client = NewClient(config.Config{BaseURL: "https://grafana.com"}, doerFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("network")
+	}))
+	if _, err := client.requestJSONWithAuth(context.Background(), http.MethodGet, "https://grafana.com", nil, "explicit-token", 0); err == nil {
+		t.Fatalf("expected requestJSONWithAuth network error")
+	}
+}
+
 func TestRequestBytesDefaultAcceptAndRenderSlugBranch(t *testing.T) {
 	requests := make([]*http.Request, 0)
 	client := NewClient(config.Config{BaseURL: "https://base"}, doerFunc(func(r *http.Request) (*http.Response, error) {
@@ -757,5 +850,93 @@ func TestJoinURL(t *testing.T) {
 	}
 	if joined, err := joinURL("https://grafana.com", "/x", nil); err != nil || joined != "https://grafana.com/x" {
 		t.Fatalf("expected join without query")
+	}
+	if normalizeExternalBaseURL("synthetic-monitoring-api-us-east-0.grafana.net") != "https://synthetic-monitoring-api-us-east-0.grafana.net" {
+		t.Fatalf("expected normalizeExternalBaseURL to add https scheme")
+	}
+	if normalizeExternalBaseURL("https://synthetic-monitoring-api-us-east-0.grafana.net/") != "https://synthetic-monitoring-api-us-east-0.grafana.net" {
+		t.Fatalf("expected normalizeExternalBaseURL to trim trailing slash")
+	}
+	if normalizeExternalBaseURL("") != "" {
+		t.Fatalf("expected empty normalizeExternalBaseURL result")
+	}
+}
+
+func TestAdditionalClientBranchCoverage(t *testing.T) {
+	requests := make([]*http.Request, 0)
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(config.Config{BaseURL: srv.URL, CloudURL: srv.URL}, srv.Client())
+
+	if _, err := client.ServiceAccounts(context.Background(), ServiceAccountListRequest{}); err != nil {
+		t.Fatalf("expected minimal service accounts request to succeed: %v", err)
+	}
+	if _, err := client.CloudAccessPolicies(context.Background(), CloudAccessPolicyListRequest{
+		Name:            "writers",
+		RealmType:       "stack",
+		RealmIdentifier: "123",
+		PageSize:        10,
+		PageCursor:      "cursor-1",
+		Region:          "us",
+		Status:          "active",
+	}); err != nil {
+		t.Fatalf("expected full cloud access policy request to succeed: %v", err)
+	}
+	if _, err := client.CloudAccessPolicy(context.Background(), "ap-2", ""); err != nil {
+		t.Fatalf("expected cloud access policy request without region to succeed: %v", err)
+	}
+	backendHost := strings.TrimPrefix(srv.URL, "https://")
+	if _, err := client.SyntheticChecks(context.Background(), SyntheticCheckListRequest{BackendURL: backendHost, Token: "sm-token"}); err != nil {
+		t.Fatalf("expected synthetic checks host-only backend request to succeed: %v", err)
+	}
+	if _, err := client.SyntheticCheck(context.Background(), SyntheticCheckGetRequest{BackendURL: backendHost, Token: "sm-token", ID: 7}); err != nil {
+		t.Fatalf("expected synthetic check host-only backend request to succeed: %v", err)
+	}
+
+	if len(requests) != 5 {
+		t.Fatalf("expected 5 requests, got %d", len(requests))
+	}
+	if requests[0].URL.RawQuery != "" {
+		t.Fatalf("expected minimal service account query to stay empty, got %s", requests[0].URL.RawQuery)
+	}
+	if requests[1].URL.Query().Get("name") != "writers" || requests[1].URL.Query().Get("realmIdentifier") != "123" || requests[1].URL.Query().Get("pageCursor") != "cursor-1" || requests[1].URL.Query().Get("status") != "active" {
+		t.Fatalf("unexpected cloud access query: %s", requests[1].URL.RawQuery)
+	}
+	if requests[2].URL.RawQuery != "" {
+		t.Fatalf("expected cloud access get without region to omit query, got %s", requests[2].URL.RawQuery)
+	}
+	if requests[3].URL.Query().Get("includeAlerts") != "" || requests[3].Header.Get("Authorization") != "Bearer sm-token" {
+		t.Fatalf("unexpected synthetic checks request: query=%s auth=%s", requests[3].URL.RawQuery, requests[3].Header.Get("Authorization"))
+	}
+	if requests[4].URL.Path != "/api/v1/check/7" {
+		t.Fatalf("unexpected synthetic check path: %s", requests[4].URL.Path)
+	}
+
+	noCall := doerFunc(func(*http.Request) (*http.Response, error) {
+		t.Fatalf("unexpected HTTP call")
+		return nil, nil
+	})
+	if _, err := NewClient(config.Config{CloudURL: "://bad"}, noCall).CloudAccessPolicies(context.Background(), CloudAccessPolicyListRequest{Region: "us"}); err == nil {
+		t.Fatalf("expected invalid cloud URL error")
+	}
+	if _, err := NewClient(config.Config{CloudURL: "://bad"}, noCall).CloudAccessPolicy(context.Background(), "ap-1", "us"); err == nil {
+		t.Fatalf("expected invalid cloud URL error for single access policy")
+	}
+	if _, err := NewClient(config.Config{BaseURL: "://bad"}, noCall).ServiceAccounts(context.Background(), ServiceAccountListRequest{}); err == nil {
+		t.Fatalf("expected invalid base URL error for service accounts")
+	}
+	if _, err := NewClient(config.Config{BaseURL: "://bad"}, noCall).ServiceAccount(context.Background(), 1); err == nil {
+		t.Fatalf("expected invalid base URL error for service account")
+	}
+	if _, err := NewClient(config.Config{}, noCall).SyntheticChecks(context.Background(), SyntheticCheckListRequest{BackendURL: "%", Token: "sm-token"}); err == nil {
+		t.Fatalf("expected invalid synthetic backend URL error")
+	}
+	if _, err := NewClient(config.Config{}, noCall).SyntheticCheck(context.Background(), SyntheticCheckGetRequest{BackendURL: "%", Token: "sm-token", ID: 1}); err == nil {
+		t.Fatalf("expected invalid synthetic backend URL error for get")
 	}
 }

--- a/internal/grafana/cloud_access.go
+++ b/internal/grafana/cloud_access.go
@@ -1,0 +1,70 @@
+package grafana
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// CloudAccessPolicyListRequest defines list filters for Grafana Cloud access policies.
+type CloudAccessPolicyListRequest struct {
+	Name            string `json:"name"`
+	RealmType       string `json:"realm_type"`
+	RealmIdentifier string `json:"realm_identifier"`
+	PageSize        int    `json:"page_size"`
+	PageCursor      string `json:"page_cursor"`
+	Region          string `json:"region"`
+	Status          string `json:"status"`
+}
+
+// CloudAccessPolicies lists Grafana Cloud access policies for a region.
+func (c *Client) CloudAccessPolicies(ctx context.Context, req CloudAccessPolicyListRequest) (any, error) {
+	if strings.TrimSpace(c.cfg.CloudURL) == "" {
+		return nil, ErrMissingBaseURL
+	}
+	q := url.Values{}
+	if strings.TrimSpace(req.Name) != "" {
+		q.Set("name", req.Name)
+	}
+	if strings.TrimSpace(req.RealmType) != "" {
+		q.Set("realmType", req.RealmType)
+	}
+	if strings.TrimSpace(req.RealmIdentifier) != "" {
+		q.Set("realmIdentifier", req.RealmIdentifier)
+	}
+	if req.PageSize > 0 {
+		q.Set("pageSize", strconv.Itoa(req.PageSize))
+	}
+	if strings.TrimSpace(req.PageCursor) != "" {
+		q.Set("pageCursor", req.PageCursor)
+	}
+	if strings.TrimSpace(req.Region) != "" {
+		q.Set("region", req.Region)
+	}
+	if strings.TrimSpace(req.Status) != "" {
+		q.Set("status", req.Status)
+	}
+	u, err := joinURL(c.cfg.CloudURL, "/api/v1/accesspolicies", q)
+	if err != nil {
+		return nil, err
+	}
+	return c.requestJSON(ctx, http.MethodGet, u, nil)
+}
+
+// CloudAccessPolicy fetches one Grafana Cloud access policy by UUID and region.
+func (c *Client) CloudAccessPolicy(ctx context.Context, id, region string) (any, error) {
+	if strings.TrimSpace(c.cfg.CloudURL) == "" {
+		return nil, ErrMissingBaseURL
+	}
+	q := url.Values{}
+	if strings.TrimSpace(region) != "" {
+		q.Set("region", region)
+	}
+	u, err := joinURL(c.cfg.CloudURL, "/api/v1/accesspolicies/"+url.PathEscape(id), q)
+	if err != nil {
+		return nil, err
+	}
+	return c.requestJSON(ctx, http.MethodGet, u, nil)
+}

--- a/internal/grafana/service_accounts.go
+++ b/internal/grafana/service_accounts.go
@@ -1,0 +1,50 @@
+package grafana
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// ServiceAccountListRequest defines filters for service-account search.
+type ServiceAccountListRequest struct {
+	Query string `json:"query"`
+	Page  int    `json:"page"`
+	Limit int    `json:"limit"`
+}
+
+// ServiceAccounts searches service accounts with paging.
+func (c *Client) ServiceAccounts(ctx context.Context, req ServiceAccountListRequest) (any, error) {
+	if strings.TrimSpace(c.cfg.BaseURL) == "" {
+		return nil, ErrMissingBaseURL
+	}
+	q := url.Values{}
+	if strings.TrimSpace(req.Query) != "" {
+		q.Set("query", req.Query)
+	}
+	if req.Page > 0 {
+		q.Set("page", strconv.Itoa(req.Page))
+	}
+	if req.Limit > 0 {
+		q.Set("perpage", strconv.Itoa(req.Limit))
+	}
+	u, err := joinURL(c.cfg.BaseURL, "/api/serviceaccounts/search", q)
+	if err != nil {
+		return nil, err
+	}
+	return c.requestJSON(ctx, http.MethodGet, u, nil)
+}
+
+// ServiceAccount fetches one service account by numeric ID.
+func (c *Client) ServiceAccount(ctx context.Context, id int64) (any, error) {
+	if strings.TrimSpace(c.cfg.BaseURL) == "" {
+		return nil, ErrMissingBaseURL
+	}
+	u, err := joinURL(c.cfg.BaseURL, "/api/serviceaccounts/"+strconv.FormatInt(id, 10), nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.requestJSON(ctx, http.MethodGet, u, nil)
+}

--- a/internal/grafana/synthetics.go
+++ b/internal/grafana/synthetics.go
@@ -1,0 +1,64 @@
+package grafana
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// SyntheticCheckListRequest defines the request for listing synthetic monitoring checks.
+type SyntheticCheckListRequest struct {
+	BackendURL    string `json:"backend_url"`
+	Token         string `json:"token"`
+	IncludeAlerts bool   `json:"include_alerts"`
+}
+
+// SyntheticCheckGetRequest defines the request for one synthetic monitoring check.
+type SyntheticCheckGetRequest struct {
+	BackendURL string `json:"backend_url"`
+	Token      string `json:"token"`
+	ID         int64  `json:"id"`
+}
+
+// SyntheticChecks lists checks from the Synthetic Monitoring API.
+func (c *Client) SyntheticChecks(ctx context.Context, req SyntheticCheckListRequest) (any, error) {
+	baseURL := normalizeExternalBaseURL(req.BackendURL)
+	if baseURL == "" {
+		return nil, ErrMissingBaseURL
+	}
+	q := url.Values{}
+	if req.IncludeAlerts {
+		q.Set("includeAlerts", "true")
+	}
+	u, err := joinURL(baseURL, "/api/v1/check", q)
+	if err != nil {
+		return nil, err
+	}
+	return c.requestJSONWithAuth(ctx, http.MethodGet, u, nil, req.Token, 0)
+}
+
+// SyntheticCheck fetches one synthetic monitoring check by ID.
+func (c *Client) SyntheticCheck(ctx context.Context, req SyntheticCheckGetRequest) (any, error) {
+	baseURL := normalizeExternalBaseURL(req.BackendURL)
+	if baseURL == "" {
+		return nil, ErrMissingBaseURL
+	}
+	u, err := joinURL(baseURL, "/api/v1/check/"+strconv.FormatInt(req.ID, 10), nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.requestJSONWithAuth(ctx, http.MethodGet, u, nil, req.Token, 0)
+}
+
+func normalizeExternalBaseURL(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return ""
+	}
+	if !strings.Contains(trimmed, "://") {
+		trimmed = "https://" + trimmed
+	}
+	return strings.TrimRight(trimmed, "/")
+}


### PR DESCRIPTION
## Summary

- add activation-oriented CLI surfaces for `service-accounts` and `cloud access-policies`
- add Synthetic Monitoring check inspection commands with explicit backend/token targeting for agent-safe use
- add `assistant investigate` as a deterministic investigation wrapper over Assistant chat
- extend discovery/help output and README examples so these flows are visible in schema-first agent loops
- add focused client + CLI tests and keep repo coverage at `100.0%`

## Agent Impact

- Token usage impact: improves agent loops by exposing narrow commands for activation, synthetics, and investigation instead of forcing broader raw API calls
- Output contract changes: adds new command families and discovery entries; existing command shapes are preserved
- Command/API behavior changes: introduces read-first commands for Cloud access policies, service accounts, Synthetic Monitoring checks, and Assistant investigation

## Quality Checklist

- [x] `golangci-lint` passes locally
- [x] `go test ./...` passes locally
- [x] Coverage is `100.0%` (`go tool cover -func=coverage.out | tail -n 1`)
- [x] Tests added/updated for behavior changes
- [x] README/docs updated when command contracts changed
