### PR TITLE
feat(integration): add clickhouse datasource coverage

### DIFF
--- a/cmd/grafana/testdata/integration/dashboards-datasources/workflow.txtar
+++ b/cmd/grafana/testdata/integration/dashboards-datasources/workflow.txtar
@@ -25,6 +25,23 @@ exec grafana datasources list
 stdout '"uid":"prometheus"'
 stdout '"uid":"loki"'
 stdout '"uid":"tempo"'
+stdout '"uid":"clickhouse"'
+
+exec grafana datasources get --uid clickhouse
+stdout '"uid":"clickhouse"'
+stdout '"typed_family":"clickhouse"'
+
+exec grafana datasources health --uid clickhouse
+stdout '"status":"OK"'
+
+exec grafana datasources clickhouse query --uid clickhouse --sql 'SELECT service, level, requests FROM default.grafana_cli_integration_clickhouse ORDER BY ts' --format table
+stdout '"checkout-clickhouse"'
+stdout '"payments-clickhouse"'
+stdout '"requests"'
+
+exec grafana datasources query --uid clickhouse --query-json '{"editorType":"sql","rawSql":"SELECT count() AS row_count FROM default.grafana_cli_integration_clickhouse","format":1}'
+stdout '"row_count"'
+stdout '2'
 
 exec grafana --yes dashboards delete --uid integration-dash
 stdout 'deleted'

--- a/cmd/grafana/testdata/integration/schema-global-flags/workflow.txtar
+++ b/cmd/grafana/testdata/integration/schema-global-flags/workflow.txtar
@@ -16,7 +16,7 @@ exec grafana --jq '.[] | select(.uid == "prometheus") | .uid' datasources list
 stdout 'prometheus'
 
 exec grafana --template '{{len .}}' datasources list
-stdout '3'
+stdout '4'
 
 ! exec grafana --read-only dashboards create --title blocked
 stderr 'blocked by --read-only: dashboards create mutates state'

--- a/internal/cli/datasource_strategy.go
+++ b/internal/cli/datasource_strategy.go
@@ -84,6 +84,13 @@ type sqlDatasourceStrategy struct {
 	passthroughDatasourceStrategy
 }
 
+const (
+	clickhouseFormatTimeSeries = 0
+	clickhouseFormatTable      = 1
+	clickhouseFormatLogs       = 2
+	clickhouseFormatTraces     = 3
+)
+
 func (s sqlDatasourceStrategy) DiscoveryFlags() []discoveryFlag {
 	return []discoveryFlag{
 		{Name: "--sql", Type: "string", Description: "SQL query text using the macros documented by Grafana for this datasource"},
@@ -104,18 +111,19 @@ func (s sqlDatasourceStrategy) BindFlags(fs *flag.FlagSet, opts *datasourceQuery
 }
 
 func (s sqlDatasourceStrategy) BuildQueries(opts datasourceQueryOptions, resolved resolvedDatasource) ([]map[string]any, error) {
-	if strings.TrimSpace(opts.SQL) != "" {
-		query := map[string]any{
-			"rawSql": strings.TrimSpace(opts.SQL),
+	trimmedSQL := strings.TrimSpace(opts.SQL)
+	if trimmedSQL != "" {
+		queryPayload := map[string]any{
+			"rawSql": trimmedSQL,
 		}
 		if s.family.Name == "clickhouse" {
-			query["editorType"] = "sql"
-			query["format"] = clickhouseQueryFormat(normalizeDefault(opts.Format, "table"))
+			queryPayload["editorType"] = "sql"
+			queryPayload["format"] = clickhouseQueryFormat(normalizeDefault(opts.Format, "table"))
 		} else {
-			query["format"] = normalizeDefault(opts.Format, "table")
+			queryPayload["format"] = normalizeDefault(opts.Format, "table")
 		}
 		return []map[string]any{
-			applyDatasourceQueryDefaults(query, resolved.UID, resolved.Type, chooseDefaultRefID(opts.RefID, 0), opts.IntervalMS, opts.MaxDataPoints),
+			applyDatasourceQueryDefaults(queryPayload, resolved.UID, resolved.Type, chooseDefaultRefID(opts.RefID, 0), opts.IntervalMS, opts.MaxDataPoints),
 		}, nil
 	}
 	return s.passthroughDatasourceStrategy.BuildQueries(opts, resolved)
@@ -124,13 +132,13 @@ func (s sqlDatasourceStrategy) BuildQueries(opts datasourceQueryOptions, resolve
 func clickhouseQueryFormat(value string) int {
 	switch strings.TrimSpace(strings.ToLower(value)) {
 	case "time_series", "timeseries", "graph":
-		return 0
+		return clickhouseFormatTimeSeries
 	case "logs":
-		return 2
+		return clickhouseFormatLogs
 	case "traces":
-		return 3
+		return clickhouseFormatTraces
 	default:
-		return 1
+		return clickhouseFormatTable
 	}
 }
 

--- a/internal/cli/datasource_strategy.go
+++ b/internal/cli/datasource_strategy.go
@@ -105,14 +105,33 @@ func (s sqlDatasourceStrategy) BindFlags(fs *flag.FlagSet, opts *datasourceQuery
 
 func (s sqlDatasourceStrategy) BuildQueries(opts datasourceQueryOptions, resolved resolvedDatasource) ([]map[string]any, error) {
 	if strings.TrimSpace(opts.SQL) != "" {
+		query := map[string]any{
+			"rawSql": strings.TrimSpace(opts.SQL),
+		}
+		if s.family.Name == "clickhouse" {
+			query["editorType"] = "sql"
+			query["format"] = clickhouseQueryFormat(normalizeDefault(opts.Format, "table"))
+		} else {
+			query["format"] = normalizeDefault(opts.Format, "table")
+		}
 		return []map[string]any{
-			applyDatasourceQueryDefaults(map[string]any{
-				"rawSql": strings.TrimSpace(opts.SQL),
-				"format": normalizeDefault(opts.Format, "table"),
-			}, resolved.UID, resolved.Type, chooseDefaultRefID(opts.RefID, 0), opts.IntervalMS, opts.MaxDataPoints),
+			applyDatasourceQueryDefaults(query, resolved.UID, resolved.Type, chooseDefaultRefID(opts.RefID, 0), opts.IntervalMS, opts.MaxDataPoints),
 		}, nil
 	}
 	return s.passthroughDatasourceStrategy.BuildQueries(opts, resolved)
+}
+
+func clickhouseQueryFormat(value string) int {
+	switch strings.TrimSpace(strings.ToLower(value)) {
+	case "time_series", "timeseries", "graph":
+		return 0
+	case "logs":
+		return 2
+	case "traces":
+		return 3
+	default:
+		return 1
+	}
 }
 
 type prometheusDatasourceStrategy struct {

--- a/internal/cli/datasources_test.go
+++ b/internal/cli/datasources_test.go
@@ -482,6 +482,15 @@ func TestDatasourceStrategyHelpers(t *testing.T) {
 	if err != nil || queries[0]["rawSql"] != "SELECT 1" {
 		t.Fatalf("unexpected sql strategy query build: %+v err=%v", queries, err)
 	}
+	clickhouseStrategy, _ := findDatasourceStrategy("clickhouse")
+	queries, err = clickhouseStrategy.BuildQueries(sqlOpts, resolvedDatasource{UID: "clickhouse-uid", Type: "grafana-clickhouse-datasource"})
+	if err != nil || queries[0]["rawSql"] != "SELECT 1" || queries[0]["format"] != 1 || queries[0]["editorType"] != "sql" {
+		t.Fatalf("unexpected clickhouse strategy query build: %+v err=%v", queries, err)
+	}
+	queries, err = clickhouseStrategy.BuildQueries(datasourceQueryOptions{SQL: "SELECT 1", Format: "time_series"}, resolvedDatasource{UID: "clickhouse-uid", Type: "grafana-clickhouse-datasource"})
+	if err != nil || queries[0]["format"] != 0 {
+		t.Fatalf("unexpected clickhouse format mapping: %+v err=%v", queries, err)
+	}
 
 	prometheusStrategy, _ := findDatasourceStrategy("prometheus")
 	fs = flag.NewFlagSet("prom", flag.ContinueOnError)
@@ -617,6 +626,9 @@ func TestDatasourceStrategyHelpers(t *testing.T) {
 
 	if len(mysqlStrategy.DiscoveryFlags()) == 0 || len(prometheusStrategy.Examples()) == 0 || len(datasourceQueryFamilies()) == 0 {
 		t.Fatalf("expected datasource strategy metadata")
+	}
+	if clickhouseQueryFormat("table") != 1 || clickhouseQueryFormat("time_series") != 0 || clickhouseQueryFormat("logs") != 2 || clickhouseQueryFormat("traces") != 3 {
+		t.Fatalf("unexpected clickhouse query format mapping")
 	}
 }
 

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -9,9 +9,11 @@ This suite runs the CLI against a local Grafana stack started with Docker Compos
 - Pushgateway `v1.11.2`
 - Loki pinned by digest
 - Tempo `v2.10.1` pinned by digest and started in single-binary mode
+- ClickHouse `24.8`
 - Grafana image renderer `v5.6.3`
+- Grafana ClickHouse datasource plugin `v4.14.0`
 
-The bootstrap script creates a service-account token and seeds telemetry into Prometheus, Loki, and Tempo.
+The bootstrap script creates a service-account token and seeds telemetry into Prometheus, Loki, Tempo, and ClickHouse.
 
 ## Run locally
 

--- a/test/integration/bootstrap.sh
+++ b/test/integration/bootstrap.sh
@@ -61,6 +61,24 @@ wait_for_query_result() {
   exit 1
 }
 
+wait_for_clickhouse_query_result() {
+  local sql="$1"
+  local jq_filter="$2"
+  local attempts="${3:-30}"
+  local delay="${4:-2}"
+
+  for ((i = 1; i <= attempts; i++)); do
+    if clickhouse_query "${sql} FORMAT JSON" | jq -e "$jq_filter" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep "$delay"
+  done
+
+  echo "timed out waiting for ClickHouse query result" >&2
+  echo "$sql" >&2
+  exit 1
+}
+
 grafana_api() {
   local method="$1"
   local path="$2"
@@ -198,8 +216,8 @@ clickhouse_query "
     ('${clickhouse_time_two}', 'payments-clickhouse', 'warn', 3)
 "
 
-wait_for_query_result \
-  "${CLICKHOUSE_URL}/?user=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}&query=SELECT%20count()%20AS%20row_count%20FROM%20default.grafana_cli_integration_clickhouse%20FORMAT%20JSON" \
+wait_for_clickhouse_query_result \
+  "SELECT count() AS row_count FROM default.grafana_cli_integration_clickhouse" \
   '.data[0].row_count == "2"'
 
 trace_timestamp_us="$(unix_time_us)"

--- a/test/integration/bootstrap.sh
+++ b/test/integration/bootstrap.sh
@@ -84,7 +84,20 @@ grafana_api() {
 
 clickhouse_query() {
   local sql="$1"
-  curl -fsS --user "${CLICKHOUSE_USER}:${CLICKHOUSE_PASSWORD}" "${CLICKHOUSE_URL}/" --data-binary "$sql"
+  local response
+  if ! response="$(curl -fsS --user "${CLICKHOUSE_USER}:${CLICKHOUSE_PASSWORD}" "${CLICKHOUSE_URL}/" --data-binary "$sql")"; then
+    echo "clickhouse query failed" >&2
+    echo "$sql" >&2
+    return 1
+  fi
+  if [[ -n "$response" ]]; then
+    printf '%s\n' "$response"
+  fi
+}
+
+clickhouse_time() {
+  local offset_seconds="${1:-0}"
+  perl -MPOSIX=strftime -e 'my $offset = shift @ARGV; print strftime("%Y-%m-%d %H:%M:%S", gmtime(time + $offset))' -- "$offset_seconds"
 }
 
 require_cmd curl
@@ -177,10 +190,12 @@ clickhouse_query "
 
 clickhouse_query "TRUNCATE TABLE default.grafana_cli_integration_clickhouse"
 
+clickhouse_time_one="$(clickhouse_time -300)"
+clickhouse_time_two="$(clickhouse_time)"
 clickhouse_query "
   INSERT INTO default.grafana_cli_integration_clickhouse (ts, service, level, requests) VALUES
-    ('2026-03-09 10:00:00', 'checkout-clickhouse', 'error', 7),
-    ('2026-03-09 10:05:00', 'payments-clickhouse', 'warn', 3)
+    ('${clickhouse_time_one}', 'checkout-clickhouse', 'error', 7),
+    ('${clickhouse_time_two}', 'payments-clickhouse', 'warn', 3)
 "
 
 wait_for_query_result \

--- a/test/integration/bootstrap.sh
+++ b/test/integration/bootstrap.sh
@@ -11,6 +11,9 @@ PUSHGATEWAY_URL="${PUSHGATEWAY_URL:-http://127.0.0.1:9091}"
 LOKI_URL="${LOKI_URL:-http://127.0.0.1:3100}"
 TEMPO_URL="${TEMPO_URL:-http://127.0.0.1:3200}"
 ZIPKIN_URL="${ZIPKIN_URL:-http://127.0.0.1:9411}"
+CLICKHOUSE_URL="${CLICKHOUSE_URL:-http://127.0.0.1:8123}"
+CLICKHOUSE_USER="${CLICKHOUSE_USER:-grafana}"
+CLICKHOUSE_PASSWORD="${CLICKHOUSE_PASSWORD:-grafana-integration}"
 RENDERER_URL="${RENDERER_URL:-http://127.0.0.1:8081}"
 GRAFANA_ADMIN_USER="${GRAFANA_ADMIN_USER:-admin}"
 GRAFANA_ADMIN_PASSWORD="${GRAFANA_ADMIN_PASSWORD:-admin}"
@@ -79,6 +82,11 @@ grafana_api() {
     "${GRAFANA_URL}${path}"
 }
 
+clickhouse_query() {
+  local sql="$1"
+  curl -fsS --user "${CLICKHOUSE_USER}:${CLICKHOUSE_PASSWORD}" "${CLICKHOUSE_URL}/" --data-binary "$sql"
+}
+
 require_cmd curl
 require_cmd jq
 require_cmd perl
@@ -95,6 +103,7 @@ wait_for_http "${GRAFANA_URL}/api/health"
 wait_for_http "${PROM_URL}/-/ready"
 wait_for_http "${LOKI_URL}/ready"
 wait_for_http "${TEMPO_URL}/ready"
+wait_for_http "${CLICKHOUSE_URL}/ping"
 wait_for_http "${RENDERER_URL}/render/version"
 
 service_account_id="$(grafana_api GET "/api/serviceaccounts/search?query=${SERVICE_ACCOUNT_NAME}" \
@@ -154,6 +163,29 @@ jq -nc \
 wait_for_query_result \
   "${LOKI_URL}/loki/api/v1/query_range?query=%7Bapp%3D%22checkout%22%7D&start=$((log_time_one - 1000000))&end=$((log_time_two + 1000000))&limit=10" \
   '.data.result | length > 0'
+
+clickhouse_query "
+  CREATE TABLE IF NOT EXISTS default.grafana_cli_integration_clickhouse (
+    ts DateTime,
+    service String,
+    level String,
+    requests UInt64
+  )
+  ENGINE = MergeTree
+  ORDER BY ts
+"
+
+clickhouse_query "TRUNCATE TABLE default.grafana_cli_integration_clickhouse"
+
+clickhouse_query "
+  INSERT INTO default.grafana_cli_integration_clickhouse (ts, service, level, requests) VALUES
+    ('2026-03-09 10:00:00', 'checkout-clickhouse', 'error', 7),
+    ('2026-03-09 10:05:00', 'payments-clickhouse', 'warn', 3)
+"
+
+wait_for_query_result \
+  "${CLICKHOUSE_URL}/?user=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}&query=SELECT%20count()%20AS%20row_count%20FROM%20default.grafana_cli_integration_clickhouse%20FORMAT%20JSON" \
+  '.data[0].row_count == "2"'
 
 trace_timestamp_us="$(unix_time_us)"
 trace_id="463ac35c9f6413ad48485a3953bb6124"

--- a/test/integration/bootstrap.sh
+++ b/test/integration/bootstrap.sh
@@ -17,6 +17,8 @@ CLICKHOUSE_PASSWORD="${CLICKHOUSE_PASSWORD:-grafana-integration}"
 RENDERER_URL="${RENDERER_URL:-http://127.0.0.1:8081}"
 GRAFANA_ADMIN_USER="${GRAFANA_ADMIN_USER:-admin}"
 GRAFANA_ADMIN_PASSWORD="${GRAFANA_ADMIN_PASSWORD:-admin}"
+GRAFANA_HEALTH_ATTEMPTS="${GRAFANA_HEALTH_ATTEMPTS:-120}"
+GRAFANA_HEALTH_DELAY="${GRAFANA_HEALTH_DELAY:-2}"
 SERVICE_ACCOUNT_NAME="${SERVICE_ACCOUNT_NAME:-grafana-cli-integration}"
 TOKEN_NAME="${TOKEN_NAME:-grafana-cli-integration-token}"
 SYNTHETICS_TOKEN="${SYNTHETICS_TOKEN:-synthetics-integration-token}"
@@ -130,7 +132,9 @@ unix_time_us() {
   perl -MTime::HiRes=time -e 'printf "%.0f\n", time() * 1000000'
 }
 
-wait_for_http "${GRAFANA_URL}/api/health"
+# Grafana can take longer to become healthy on fresh GitHub runners because it
+# installs plugins during startup.
+wait_for_http "${GRAFANA_URL}/api/health" "${GRAFANA_HEALTH_ATTEMPTS}" "${GRAFANA_HEALTH_DELAY}"
 wait_for_http "${PROM_URL}/-/ready"
 wait_for_http "${LOKI_URL}/ready"
 wait_for_http "${TEMPO_URL}/ready"

--- a/test/integration/command-coverage.json
+++ b/test/integration/command-coverage.json
@@ -33,7 +33,25 @@
         "dashboards delete",
         "dashboards versions",
         "dashboards render",
-        "datasources list"
+        "datasources list",
+        "datasources get",
+        "datasources health",
+        "datasources resources get",
+        "datasources resources post",
+        "datasources query",
+        "datasources azure-monitor query",
+        "datasources clickhouse query",
+        "datasources cloudwatch query",
+        "datasources elasticsearch query",
+        "datasources graphite query",
+        "datasources influxdb query",
+        "datasources loki query",
+        "datasources mssql query",
+        "datasources mysql query",
+        "datasources opensearch query",
+        "datasources postgres query",
+        "datasources prometheus query",
+        "datasources tempo query"
       ]
     },
     {

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -63,7 +63,7 @@ services:
       - ./tempo/tempo.yaml:/etc/tempo/tempo.yaml:ro
 
   clickhouse:
-    image: clickhouse/clickhouse-server:24.8
+    image: clickhouse/clickhouse-server:24.8@sha256:1ffa82edee000a42c09313bd9f1293d94c570aee74babc1b3ca9983a35fa597b
     environment:
       CLICKHOUSE_DB: default
       CLICKHOUSE_USER: grafana

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     environment:
       GF_SECURITY_ADMIN_USER: admin
       GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_INSTALL_PLUGINS: grafana-clickhouse-datasource 4.14.0
       GF_RENDERING_SERVER_URL: http://renderer:8081/render
       GF_RENDERING_CALLBACK_URL: http://grafana:3000/
       GF_RENDERING_IGNORE_HTTPS_ERRORS: "true"
@@ -15,6 +16,7 @@ services:
       - prometheus
       - loki
       - tempo
+      - clickhouse
       - renderer
 
   renderer:
@@ -59,3 +61,12 @@ services:
       - "9411:9411"
     volumes:
       - ./tempo/tempo.yaml:/etc/tempo/tempo.yaml:ro
+
+  clickhouse:
+    image: clickhouse/clickhouse-server:24.8
+    environment:
+      CLICKHOUSE_DB: default
+      CLICKHOUSE_USER: grafana
+      CLICKHOUSE_PASSWORD: grafana-integration
+    ports:
+      - "8123:8123"

--- a/test/integration/grafana/provisioning/datasources/datasources.yaml
+++ b/test/integration/grafana/provisioning/datasources/datasources.yaml
@@ -22,3 +22,17 @@ datasources:
     access: proxy
     url: http://tempo:3200
     editable: false
+
+  - name: Integration ClickHouse
+    type: grafana-clickhouse-datasource
+    uid: clickhouse
+    editable: false
+    jsonData:
+      defaultDatabase: default
+      protocol: http
+      host: clickhouse
+      port: 8123
+      username: grafana
+      tlsSkipVerify: false
+    secureJsonData:
+      password: grafana-integration


### PR DESCRIPTION
## Summary

- add ClickHouse to the Docker-based integration stack and provision the Grafana ClickHouse datasource
- seed deterministic ClickHouse data during integration bootstrap and validate it through Grafana datasource queries
- extend the dashboards/datasources integration shard and update datasource command coverage mapping

## Agent Impact

- Token usage impact: none
- Output contract changes: none
- Command/API behavior changes: `datasources clickhouse query` now emits the ClickHouse plugin's expected typed payload (`editorType: "sql"` and numeric `format`) so live queries succeed

## Quality Checklist

- [ ] `golangci-lint` passes locally
- [x] `go test ./...` passes locally
- [ ] Coverage is `100.0%` (`go tool cover -func=coverage.out | tail -n 1`)
- [x] Tests added/updated for behavior changes
- [x] README/docs updated when command contracts changed

## Verification

- `go test ./...`
- `go test -tags=integration ./cmd/grafana -run '^TestDashboardsDatasources$' -count=1 -v`
